### PR TITLE
Features/pass used columns and where to data sources

### DIFF
--- a/Musoq.Converter/Build/BuildItems.cs
+++ b/Musoq.Converter/Build/BuildItems.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 
 namespace Musoq.Converter.Build
@@ -72,6 +73,12 @@ namespace Musoq.Converter.Build
         {
             get => (EmitResult) this["EMIT_RESULT"];
             set => this["EMIT_RESULT"] = value;
+        }
+
+        public IReadOnlyDictionary<SchemaFromNode, ISchemaColumn[]> UsedColumns 
+        {
+            get => (IReadOnlyDictionary<SchemaFromNode, ISchemaColumn[]>) this["USED_COLUMNS"];
+            set => this["USED_COLUMNS"] = value;
         }
     }
 }

--- a/Musoq.Converter/Build/BuildItems.cs
+++ b/Musoq.Converter/Build/BuildItems.cs
@@ -80,5 +80,11 @@ namespace Musoq.Converter.Build
             get => (IReadOnlyDictionary<SchemaFromNode, ISchemaColumn[]>) this["USED_COLUMNS"];
             set => this["USED_COLUMNS"] = value;
         }
+
+        public IReadOnlyDictionary<SchemaFromNode, WhereNode> UsedWhereNodes
+        {
+            get => (IReadOnlyDictionary<SchemaFromNode, WhereNode>) this["USED_WHERE_NODES"];
+            set => this["USED_WHERE_NODES"] = value;
+        }
     }
 }

--- a/Musoq.Converter/Build/TranformTree.cs
+++ b/Musoq.Converter/Build/TranformTree.cs
@@ -36,6 +36,7 @@ namespace Musoq.Converter.Build
 
             queryTree.Accept(csharpRewriteTraverser);
 
+            items.UsedColumns = metadataInferer.UsedColumns;
             items.TransformedQueryTree = queryTree;
             items.Compilation = csharpRewriter.Compilation;
             items.AccessToClassPath = csharpRewriter.AccessToClassPath;

--- a/Musoq.Converter/Build/TurnQueryIntoRunnableCode.cs
+++ b/Musoq.Converter/Build/TurnQueryIntoRunnableCode.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Text;
+using Microsoft.CodeAnalysis.Emit;
 using Musoq.Converter.Exceptions;
 
 namespace Musoq.Converter.Build

--- a/Musoq.Converter/InstanceCreator.cs
+++ b/Musoq.Converter/InstanceCreator.cs
@@ -16,7 +16,7 @@ namespace Musoq.Converter
 {
     public static class InstanceCreator
     {
-        public static (byte[] DllFile, byte[] PdbFile) CompileForStore(string script, string assemblyName, ISchemaProvider provider)
+        public static BuildItems CreateForAnalyze(string script, string assemblyName, ISchemaProvider provider)
         {
             var items = new BuildItems
             {
@@ -32,6 +32,13 @@ namespace Musoq.Converter
                     new TurnQueryIntoRunnableCode(null)));
 
             chain.Build(items);
+
+            return items;
+        }
+        
+        public static (byte[] DllFile, byte[] PdbFile) CompileForStore(string script, string assemblyName, ISchemaProvider provider)
+        {
+            var items = CreateForAnalyze(script, assemblyName, provider);
 
             return (items.DllFile, items.PdbFile);
         }
@@ -146,6 +153,9 @@ namespace Musoq.Converter
             
             runnable.Provider = items.SchemaProvider;
             runnable.PositionalEnvironmentVariables = items.PositionalEnvironmentVariables;
+            runnable.QueriesInformation =
+                items.UsedColumns.ToDictionary(f => f.Key.Alias,
+                    f => (f.Key, f.Value as IReadOnlyCollection<ISchemaColumn>));
 
             return runnable;
         }

--- a/Musoq.Converter/Musoq.Converter.csproj
+++ b/Musoq.Converter/Musoq.Converter.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Evaluator.Tests/PassPrimitiveTypesTests.cs
+++ b/Musoq.Evaluator.Tests/PassPrimitiveTypesTests.cs
@@ -76,7 +76,6 @@ namespace Musoq.Evaluator.Tests
 
         private class TestSchema : SchemaBase
         {
-
             private readonly IEnumerable<TestEntity> _entities;
             private readonly Action<object[]> _onGetTableOrRowSource;
             private readonly WhenCheckedParameters _whenChecked;

--- a/Musoq.Evaluator.Tests/RewriteWhereExpressionToPassItToDataSourceTests.cs
+++ b/Musoq.Evaluator.Tests/RewriteWhereExpressionToPassItToDataSourceTests.cs
@@ -1,0 +1,233 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Musoq.Evaluator.Tests.Schema.Basic;
+
+namespace Musoq.Evaluator.Tests;
+
+[TestClass]
+public class RewriteWhereExpressionToPassItToDataSourceTests : BasicEntityTestBase
+{
+    [TestMethod]
+    public void WhenWhereExpressionIsNotRewritten_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.Population > 0";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("a.Population > 0", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenLikeExpressionIsRewritten_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.City like '%abc%'";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("1 = 1", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenRLikeExpressionIsRewritten_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.City rlike '%abc%'";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("1 = 1", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenContainsExpressionIsNotRewritten_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.City contains ('abc', 'def')";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("a.City contains ('abc', 'def')", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenContainsExpressionIsRewritten_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.City contains (DoNothing('abc'), 'def')";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("1 = 1", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenWhereExpressionIsNotRewrittenAndUsesConditionOnTwoColumns_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a where a.Population > a.Population";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        
+        Assert.AreEqual("a.Population > a.Population", firstWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenWhereExpressionUsesMustBeRewrittenForBothDataSources_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a inner join #B.entities() b on a.City = b.City where a.Population > 0";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(2, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+        var secondWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "b").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.IsNotNull(secondWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        Assert.AreEqual(1, secondWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        var secondWhereNode = secondWhereNodePair.First().Value;
+        
+        Assert.AreEqual("a.Population > 0", firstWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1", secondWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenWhereExpressionMustBeRewrittenDueToExchangingColumnsBetweenTwoSources_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a inner join #B.entities() b on a.City = b.City where a.Population > b.Population";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(2, buildItems.UsedWhereNodes.Count);
+
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+        var secondWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "b").ToArray();
+
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.IsNotNull(secondWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        Assert.AreEqual(1, secondWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        var secondWhereNode = secondWhereNodePair.First().Value;
+        
+        Assert.AreEqual("1 = 1", firstWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1", secondWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenWhereExpressionMustBeRewrittenDueToExchangingColumnsBetweenThreeSources_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a inner join #B.entities() b on a.City = b.City inner join #C.entities() c on b.City = c.City where a.Population > b.Population and c.Population = 200d";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(3, buildItems.UsedWhereNodes.Count);
+        
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "a").ToArray();
+        var secondWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "b").ToArray();
+        var thirdWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "c").ToArray();
+        
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.IsNotNull(secondWhereNodePair);
+        Assert.IsNotNull(thirdWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        Assert.AreEqual(1, secondWhereNodePair.Length);
+        Assert.AreEqual(1, thirdWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        var secondWhereNode = secondWhereNodePair.First().Value;
+        var thirdWhereNode = thirdWhereNodePair.First().Value;
+        
+        Assert.AreEqual("1 = 1 and 1 = 1", firstWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1 and 1 = 1", secondWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1 and c.Population = 200", thirdWhereNode.Expression.ToString());
+    }
+    
+    [TestMethod]
+    public void WhenCteUsedWithExchangeParametersBetweenSources_ShouldPass()
+    {
+        var query = @"
+with a as (
+    select City, Population from #A.entities() x where x.Population > 100d 
+)
+select 1 from a firstTable inner join #B.entities() b on firstTable.City = b.City inner join #C.entities() c on b.City = c.City where firstTable.Population > b.Population and c.Population = 200d";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(3, buildItems.UsedWhereNodes.Count);
+        
+        var firstWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "x").ToArray();
+        var secondWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "b").ToArray();
+        var thirdWhereNodePair = buildItems.UsedWhereNodes.Where(f => f.Key.Alias == "c").ToArray();
+        
+        Assert.IsNotNull(firstWhereNodePair);
+        Assert.IsNotNull(secondWhereNodePair);
+        Assert.IsNotNull(thirdWhereNodePair);
+        Assert.AreEqual(1, firstWhereNodePair.Length);
+        Assert.AreEqual(1, secondWhereNodePair.Length);
+        Assert.AreEqual(1, thirdWhereNodePair.Length);
+        
+        var firstWhereNode = firstWhereNodePair.First().Value;
+        var secondWhereNode = secondWhereNodePair.First().Value;
+        var thirdWhereNode = thirdWhereNodePair.First().Value;
+        
+        Assert.AreEqual("x.Population > 100", firstWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1 and 1 = 1", secondWhereNode.Expression.ToString());
+        Assert.AreEqual("1 = 1 and c.Population = 200", thirdWhereNode.Expression.ToString());
+    }
+}

--- a/Musoq.Evaluator.Tests/Schema/Basic/BasicEntityTestBase.cs
+++ b/Musoq.Evaluator.Tests/Schema/Basic/BasicEntityTestBase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Musoq.Converter;
+using Musoq.Converter.Build;
 using Musoq.Plugins;
 using Musoq.Tests.Common;
 
@@ -13,6 +14,18 @@ namespace Musoq.Evaluator.Tests.Schema.Basic
     public class BasicEntityTestBase
     {
         protected CancellationTokenSource TokenSource { get; } = new();
+        
+        protected BuildItems CreateBuildItems<T>(
+            string script)
+            where T : BasicEntity
+        {
+            var mock = new Mock<IDictionary<string, IEnumerable<T>>>();
+            mock.Setup(f => f[It.IsAny<string>()]).Returns(new List<T>());
+            return InstanceCreator.CreateForAnalyze(
+                script, 
+                Guid.NewGuid().ToString(), 
+                new BasicSchemaProvider<T>(mock.Object));
+        }
 
         protected CompiledQuery CreateAndRunVirtualMachine<T>(
             string script,

--- a/Musoq.Evaluator.Tests/Schema/Basic/TestLibrary.cs
+++ b/Musoq.Evaluator.Tests/Schema/Basic/TestLibrary.cs
@@ -8,6 +8,12 @@ namespace Musoq.Evaluator.Tests.Schema.Basic
     public class TestLibrary : LibraryBase
     {
         private readonly Random _random = new();
+        
+        [BindableMethod]
+        public T DoNothing<T>(T value)
+        {
+            return value;
+        }
 
         [BindableMethod]
         public string Name([InjectSource] BasicEntity entity)

--- a/Musoq.Evaluator.Tests/Schema/Basic/TestSchema.cs
+++ b/Musoq.Evaluator.Tests/Schema/Basic/TestSchema.cs
@@ -10,7 +10,6 @@ namespace Musoq.Evaluator.Tests.Schema.Basic
     {
         private static readonly IDictionary<string, int> TestNameToIndexMap;
         private static readonly IDictionary<int, Func<T, object>> TestIndexToObjectAccessMap;
-        private readonly IEnumerable<T> _sources;
 
         static TestSchema()
         {
@@ -46,8 +45,7 @@ namespace Musoq.Evaluator.Tests.Schema.Basic
         public TestSchema(IEnumerable<T> sources)
             : base("test", CreateLibrary())
         {
-            _sources = sources;
-            AddSource<EntitySource<T>>("entities", _sources, TestNameToIndexMap, TestIndexToObjectAccessMap);
+            AddSource<EntitySource<T>>("entities", sources, TestNameToIndexMap, TestIndexToObjectAccessMap);
             AddTable<BasicEntityTable>("entities");
         }
 

--- a/Musoq.Evaluator.Tests/UsedColumnsTests.cs
+++ b/Musoq.Evaluator.Tests/UsedColumnsTests.cs
@@ -128,4 +128,28 @@ public class UsedColumnsTests : BasicEntityTestBase
         Assert.AreEqual(1, columnsB.Length);
         Assert.IsTrue(columnsB.Select(f => f.ColumnName).Contains("City"));
     }
+
+    [TestMethod]
+    public void WhenGroupByAndOrderByUsed_ShouldPass()
+    {
+        var query = "select 1 from #A.entities() a inner join #B.entities() b on a.Population = b.Population group by a.City";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(2, buildItems.UsedColumns.Count);
+        
+        var columnsA = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(2, columnsA.Length);
+        
+        var columnsB = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "b")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(1, columnsB.Length);
+    }
 }

--- a/Musoq.Evaluator.Tests/UsedColumnsTests.cs
+++ b/Musoq.Evaluator.Tests/UsedColumnsTests.cs
@@ -1,0 +1,131 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Musoq.Evaluator.Tests.Schema.Basic;
+
+namespace Musoq.Evaluator.Tests;
+
+[TestClass]
+public class UsedColumnsTests : BasicEntityTestBase
+{
+    [TestMethod]
+    public void WhenColumnsUsedAsSourceOfMethod_ShouldPass()
+    {
+        var query = "select DoNothing(a.City) from #A.entities() a";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedColumns.Count);
+        
+        var columns = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(1, columns.Length);
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("City"));
+    }
+    
+    [TestMethod]
+    public void WhenColumnsUsedAsSourceOfMethodAndUsedInWhere_ShouldPass()
+    {
+        var query = "select a.City from #A.entities() a where DoNothing(a.Population) = 400d";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedColumns.Count);
+        
+        var columns = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(2, columns.Length);
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("City"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Population"));
+    }
+    
+    [TestMethod]
+    public void WhenColumnsUsedAsSourceOfMethodAndUsedInWhereAndUsedInSelect_ShouldPass()
+    {
+        var query = "select a.City, DoNothing(a.Population) from #A.entities() a where DoNothing(a.Population) = 400d";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedColumns.Count);
+        
+        var columns = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(2, columns.Length);
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("City"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Population"));
+    }
+    
+    [TestMethod]
+    public void WhenColumnsUsedAsSourceOfMethodAndUsedInWhereAndUsedInSelectAndUsedInGroupBy_ShouldPass()
+    {
+        var query = "select a.City, DoNothing(a.Population) from #A.entities() a where DoNothing(a.Population) = 400d group by a.Month";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedColumns.Count);
+        
+        var columns = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(3, columns.Length);
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("City"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Population"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Month"));
+    }
+    
+    [TestMethod]
+    public void WhenColumnsUsedAsSourceOfMethodAndUsedInWhereAndUsedInSelectAndUsedInGroupByWithHaving_ShouldPass()
+    {
+        var query = "select a.City from #A.entities() a group by a.Month having a.Population > 100d";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(1, buildItems.UsedColumns.Count);
+        
+        var columns = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(3, columns.Length);
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("City"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Population"));
+        Assert.IsTrue(columns.Select(f => f.ColumnName).Contains("Month"));
+    }
+    
+    [TestMethod]
+    public void WhenColumnsUsedInJoinQuery_ShouldPass()
+    {
+        var query = "select a.City, b.City from #A.entities() a inner join #B.entities() b on a.City = b.City";
+
+        var buildItems = CreateBuildItems<BasicEntity>(query);
+        
+        Assert.AreEqual(2, buildItems.UsedColumns.Count);
+        
+        var columnsA = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "a")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(1, columnsA.Length);
+        Assert.IsTrue(columnsA.Select(f => f.ColumnName).Contains("City"));
+        
+        var columnsB = 
+            buildItems.UsedColumns
+                .Where(f => f.Key.Alias == "b")
+                .Select(f => f.Value).First();
+        
+        Assert.AreEqual(1, columnsB.Length);
+        Assert.IsTrue(columnsB.Select(f => f.ColumnName).Contains("City"));
+    }
+}

--- a/Musoq.Evaluator/Helpers/AccessMethodNodesHelper.cs
+++ b/Musoq.Evaluator/Helpers/AccessMethodNodesHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using Musoq.Parser.Nodes;
+using Musoq.Plugins.Attributes;
+
+namespace Musoq.Evaluator.Helpers;
+
+public static class AccessMethodNodesHelper
+{
+    public static bool IsAggregateMethod(this AccessMethodNode node)
+    {
+        return node.Method != null && node.Method.GetCustomAttribute<AggregationMethodAttribute>() != null;
+    }
+}

--- a/Musoq.Evaluator/IRunnable.cs
+++ b/Musoq.Evaluator/IRunnable.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using Musoq.Evaluator.Tables;
+using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 
 namespace Musoq.Evaluator
@@ -10,6 +11,8 @@ namespace Musoq.Evaluator
         ISchemaProvider Provider { get; set; }
         
         IReadOnlyDictionary<uint, IReadOnlyDictionary<string, string>> PositionalEnvironmentVariables { get; set; }
+        
+        IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns)> QueriesInformation { get; set; }
 
         Table Run(CancellationToken token);
     }

--- a/Musoq.Evaluator/IRunnable.cs
+++ b/Musoq.Evaluator/IRunnable.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using Musoq.Evaluator.Tables;
+using Musoq.Parser.Nodes;
 using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 
@@ -12,7 +13,7 @@ namespace Musoq.Evaluator
         
         IReadOnlyDictionary<uint, IReadOnlyDictionary<string, string>> PositionalEnvironmentVariables { get; set; }
         
-        IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns)> QueriesInformation { get; set; }
+        IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns, WhereNode WhereNode)> QueriesInformation { get; set; }
 
         Table Run(CancellationToken token);
     }

--- a/Musoq.Evaluator/Musoq.Evaluator.csproj
+++ b/Musoq.Evaluator/Musoq.Evaluator.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.1</Version>
+    <Version>5.0.1</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Evaluator/Parser/AliasedFromNode.cs
+++ b/Musoq.Evaluator/Parser/AliasedFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class AliasedFromNode : Musoq.Parser.Nodes.From.AliasedFromNode
+{
+    public AliasedFromNode(string identifier, ArgsListNode args, string alias) 
+        : base(identifier, args, alias, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/ExpressionFromNode.cs
+++ b/Musoq.Evaluator/Parser/ExpressionFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class ExpressionFromNode : Musoq.Parser.Nodes.From.ExpressionFromNode
+{
+    public ExpressionFromNode(FromNode fromNode) 
+        : base(fromNode, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/InMemoryGroupedFromNode.cs
+++ b/Musoq.Evaluator/Parser/InMemoryGroupedFromNode.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class InMemoryGroupedFromNode : Musoq.Parser.Nodes.From.InMemoryGroupedFromNode
+{
+    public InMemoryGroupedFromNode(string alias) 
+        : base(alias, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/InMemoryTableFromNode.cs
+++ b/Musoq.Evaluator/Parser/InMemoryTableFromNode.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class InMemoryTableFromNode : Musoq.Parser.Nodes.From.InMemoryTableFromNode
+{
+    public InMemoryTableFromNode(string variableName, string alias) 
+        : base(variableName, alias, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/JoinFromNode.cs
+++ b/Musoq.Evaluator/Parser/JoinFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class JoinFromNode : Musoq.Parser.Nodes.From.JoinFromNode
+{
+    public JoinFromNode(FromNode joinFrom, FromNode from, Node expression, JoinType joinType) 
+        : base(joinFrom, from, expression, joinType, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/JoinInMemoryWithSourceTableFromNode.cs
+++ b/Musoq.Evaluator/Parser/JoinInMemoryWithSourceTableFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class JoinInMemoryWithSourceTableFromNode : Musoq.Parser.Nodes.From.JoinInMemoryWithSourceTableFromNode
+{
+    public JoinInMemoryWithSourceTableFromNode(string inMemoryTableAlias, FromNode sourceTable, Node expression, JoinType joinType) 
+        : base(inMemoryTableAlias, sourceTable, expression, joinType, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/JoinSourcesTableFromNode.cs
+++ b/Musoq.Evaluator/Parser/JoinSourcesTableFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class JoinSourcesTableFromNode : Musoq.Parser.Nodes.From.JoinSourcesTableFromNode
+{
+    public JoinSourcesTableFromNode(FromNode first, FromNode second, Node expression, JoinType joinType) 
+        : base(first, second ,expression, joinType, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/JoinsNode.cs
+++ b/Musoq.Evaluator/Parser/JoinsNode.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class JoinsNode : Musoq.Parser.Nodes.From.JoinsNode
+{
+    public JoinsNode(JoinFromNode joins) 
+        : base(joins, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/ReferentialFromNode.cs
+++ b/Musoq.Evaluator/Parser/ReferentialFromNode.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class ReferentialFromNode : Musoq.Parser.Nodes.From.ReferentialFromNode
+{
+    public ReferentialFromNode(string name, string alias) 
+        : base(name, alias, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/SchemaFromNode.cs
+++ b/Musoq.Evaluator/Parser/SchemaFromNode.cs
@@ -1,0 +1,12 @@
+﻿using Musoq.Parser.Nodes;
+using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class SchemaFromNode : Musoq.Parser.Nodes.From.SchemaFromNode
+{
+    public SchemaFromNode(string schema, string method, ArgsListNode parameters, string alias) 
+        : base(schema, method, parameters, alias, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/Parser/SchemaMethodFromNode.cs
+++ b/Musoq.Evaluator/Parser/SchemaMethodFromNode.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Schema.DataSources;
+
+namespace Musoq.Evaluator.Parser;
+
+public class SchemaMethodFromNode : Musoq.Parser.Nodes.From.SchemaMethodFromNode
+{
+    public SchemaMethodFromNode(string schema, string method) 
+        : base(schema, method, typeof(RowSource))
+    {
+    }
+}

--- a/Musoq.Evaluator/RunnableDebugDecorator.cs
+++ b/Musoq.Evaluator/RunnableDebugDecorator.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading;
 using Musoq.Evaluator.Tables;
+using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 
 namespace Musoq.Evaluator
@@ -27,6 +28,12 @@ namespace Musoq.Evaluator
         {
             get => _runnable.PositionalEnvironmentVariables;
             set => _runnable.PositionalEnvironmentVariables = value;
+        }
+
+        public IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns)> QueriesInformation
+        {
+            get => _runnable.QueriesInformation;
+            set => _runnable.QueriesInformation = value;
         }
 
         public Table Run(CancellationToken token)

--- a/Musoq.Evaluator/RunnableDebugDecorator.cs
+++ b/Musoq.Evaluator/RunnableDebugDecorator.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading;
 using Musoq.Evaluator.Tables;
+using Musoq.Parser.Nodes;
 using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 
@@ -30,7 +31,7 @@ namespace Musoq.Evaluator
             set => _runnable.PositionalEnvironmentVariables = value;
         }
 
-        public IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns)> QueriesInformation
+        public IReadOnlyDictionary<string, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> UsedColumns, WhereNode WhereNode)> QueriesInformation
         {
             get => _runnable.QueriesInformation;
             set => _runnable.QueriesInformation = value;

--- a/Musoq.Evaluator/Utils/Symbols/TableSymbol.cs
+++ b/Musoq.Evaluator/Utils/Symbols/TableSymbol.cs
@@ -38,6 +38,8 @@ namespace Musoq.Evaluator.Utils.Symbols
         public bool HasAlias { get; }
 
         public string[] CompoundTables => _orders.ToArray();
+        
+        public bool IsCompound => _orders.Count > 1;
 
         public (ISchema Schema, ISchemaTable Table, string TableName) GetTableByColumnName(string column)
         {

--- a/Musoq.Evaluator/Visitors/BuildMetadataAndInferTypeTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/BuildMetadataAndInferTypeTraverseVisitor.cs
@@ -5,6 +5,7 @@ using Musoq.Evaluator.Utils;
 using Musoq.Evaluator.Utils.Symbols;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {

--- a/Musoq.Evaluator/Visitors/BuildMetadataAndInferTypeVisitor.cs
+++ b/Musoq.Evaluator/Visitors/BuildMetadataAndInferTypeVisitor.cs
@@ -14,6 +14,7 @@ using Musoq.Evaluator.Utils.Symbols;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
 using Musoq.Parser.Tokens;
+using Musoq.Parser.Nodes.From;
 using Musoq.Plugins.Attributes;
 using Musoq.Schema;
 using Musoq.Schema.DataSources;
@@ -29,6 +30,7 @@ namespace Musoq.Evaluator.Visitors
         private readonly IDictionary<string, ISchemaTable> _explicitlyDefinedTables = new Dictionary<string, ISchemaTable>();
         private readonly IDictionary<string, string> _explicitlyCoupledTablesWithAliases = new Dictionary<string, string>();
         private readonly IDictionary<string, SchemaMethodFromNode> _explicitlyUsedAliases = new Dictionary<string, SchemaMethodFromNode>();
+        private readonly IDictionary<string, List<ISchemaColumn>> _usedColumns = new Dictionary<string, List<ISchemaColumn>>();
         private readonly List<FieldNode> _groupByFields = new();
 
         private int _setKey;
@@ -52,7 +54,23 @@ namespace Musoq.Evaluator.Visitors
         public IDictionary<string, int[]> SetOperatorFieldPositions { get; } = new Dictionary<string, int[]>();
 
         
-        public IDictionary<SchemaFromNode, ISchemaColumn[]> InferredColumns = new Dictionary<SchemaFromNode, ISchemaColumn[]>();
+        public IDictionary<SchemaFromNode, ISchemaColumn[]> InferredColumns { get; } = new Dictionary<SchemaFromNode, ISchemaColumn[]>();
+
+        public IReadOnlyDictionary<SchemaFromNode, ISchemaColumn[]> UsedColumns
+        {
+            get
+            {
+                var result = new Dictionary<SchemaFromNode, ISchemaColumn[]>();
+                
+                foreach (var aliasColumnsPair in _usedColumns)
+                {
+                    var schemaFromNode = InferredColumns.Keys.Single(f => f.Alias == aliasColumnsPair.Key);
+                    result.Add(schemaFromNode, aliasColumnsPair.Value.ToArray());
+                }
+
+                return result;
+            }
+        }
 
         public RootNode Root => (RootNode) Nodes.Peek();
 
@@ -284,17 +302,16 @@ namespace Musoq.Evaluator.Visitors
 
         public void Visit(AccessColumnNode node)
         {
-            var identifier = _currentScope.ContainsAttribute(MetaAttributes.ProcessedQueryId)
+            var hasProcessedQueryId = _currentScope.ContainsAttribute(MetaAttributes.ProcessedQueryId);
+            var identifier = hasProcessedQueryId
                 ? _currentScope[MetaAttributes.ProcessedQueryId]
                 : _identifier;
 
             var tableSymbol = _currentScope.ScopeSymbolTable.GetSymbol<TableSymbol>(identifier);
 
-            (ISchema Schema, ISchemaTable Table, string TableName) tuple;
-            if (!string.IsNullOrEmpty(node.Alias))
-                tuple = tableSymbol.GetTableByAlias(node.Alias);
-            else
-                tuple = tableSymbol.GetTableByColumnName(node.Name);
+            var tuple = !string.IsNullOrEmpty(node.Alias) ? 
+                tableSymbol.GetTableByAlias(node.Alias) : 
+                tableSymbol.GetTableByColumnName(node.Name);
 
             ISchemaColumn column;
             try
@@ -307,39 +324,25 @@ namespace Musoq.Evaluator.Visitors
             }
 
             if (column == null)
+            {
                 PrepareAndThrowUnknownColumnExceptionMessage(node.Name, tuple.Table.Columns);
+                return;
+            }
 
             AddAssembly(column.ColumnType.Assembly);
             node.ChangeReturnType(column.ColumnType);
+            
+            if (_usedColumns.TryGetValue(tuple.TableName, out var columns))
+            {
+                if (columns.All(c => c.ColumnName != column.ColumnName))
+                {
+                    columns.Add(column);
+                }
+            }
 
             var accessColumn = new AccessColumnNode(column.ColumnName, tuple.TableName, column.ColumnType, node.Span);
+            
             Nodes.Push(accessColumn);
-        }
-
-        private static void PrepareAndThrowUnknownColumnExceptionMessage(string indetifier, ISchemaColumn[] columns)
-        {
-            var library = new TransitionLibrary();
-            var candidates = new StringBuilder();
-
-            var candidatesColumns = columns.Where(col =>
-                library.Soundex(col.ColumnName) == library.Soundex(indetifier) ||
-                library.LevenshteinDistance(col.ColumnName, indetifier).Value < 3).ToArray();
-
-            for (int i = 0; i < candidatesColumns.Length - 1; i++)
-            {
-                ISchemaColumn candidate = candidatesColumns[i];
-                candidates.Append(candidate.ColumnName);
-                candidates.Append(", ");
-            }
-
-            if (candidatesColumns.Length > 0)
-            {
-                candidates.Append(candidatesColumns[^1].ColumnName);
-
-                throw new UnknownColumnException($"Column '{indetifier}' could not be found. Did you mean to use [{candidates.ToString()}]?");
-            }
-
-            throw new UnknownColumnException($"Column {indetifier} could not be found.");
         }
 
         public void Visit(AllColumnsNode node)
@@ -356,7 +359,13 @@ namespace Musoq.Evaluator.Visitors
                 AddAssembly(column.ColumnType.Assembly);
                 _generatedColumns[i] =
                     new FieldNode(
-                        new AccessColumnNode(column.ColumnName, _identifier, column.ColumnType, TextSpan.Empty), i,
+                        new AccessColumnNode(
+                            column.ColumnName, 
+                            _identifier, 
+                            column.ColumnType, 
+                            TextSpan.Empty
+                        ), 
+                        i,
                         tableSymbol.HasAlias ? _identifier : column.ColumnName);
             }
 
@@ -477,11 +486,9 @@ namespace Musoq.Evaluator.Visitors
         {
             var schema = _provider.GetSchema(node.Schema);
 
-            ISchemaTable table;
-            if (_currentScope.Name != "Desc")
-                table = schema.GetTableByName(node.Method, _schemaFromArgs.ToArray());
-            else
-                table = new DynamicTable(Array.Empty<ISchemaColumn>());
+            var table = _currentScope.Name != "Desc" ? 
+                schema.GetTableByName(node.Method, _schemaFromArgs.ToArray()) : 
+                new DynamicTable(Array.Empty<ISchemaColumn>());
 
             _schemaFromArgs.Clear();
 
@@ -494,17 +501,20 @@ namespace Musoq.Evaluator.Visitors
             _currentScope.ScopeSymbolTable.AddSymbol(_queryAlias, tableSymbol);
             _currentScope[node.Id] = _queryAlias;
 
-            var aliasedSchemaFromNode = new SchemaFromNode(node.Schema, node.Method, (ArgsListNode)Nodes.Pop(), _queryAlias);
+            var aliasedSchemaFromNode = new Parser.SchemaFromNode(node.Schema, node.Method, (ArgsListNode)Nodes.Pop(), _queryAlias);
 
             if(!InferredColumns.ContainsKey(aliasedSchemaFromNode))
                 InferredColumns.Add(aliasedSchemaFromNode, table.Columns);
+
+            if (!_usedColumns.ContainsKey(_queryAlias))
+                _usedColumns.Add(_queryAlias, new List<ISchemaColumn>());
 
             Nodes.Push(aliasedSchemaFromNode);
         }
 
         public void Visit(SchemaMethodFromNode node)
         {
-            Nodes.Push(new SchemaMethodFromNode(node.Schema, node.Method));
+            Nodes.Push(new Parser.SchemaMethodFromNode(node.Schema, node.Method));
         }
 
         public void Visit(AliasedFromNode node)
@@ -524,10 +534,13 @@ namespace Musoq.Evaluator.Visitors
             _currentScope.ScopeSymbolTable.AddSymbol(_queryAlias, tableSymbol);
             _currentScope[node.Id] = _queryAlias;
 
-            var aliasedSchemaFromNode = new SchemaFromNode(schemaInfo.Schema, schemaInfo.Method, node.Args, _queryAlias);
+            var aliasedSchemaFromNode = new Parser.SchemaFromNode(schemaInfo.Schema, schemaInfo.Method, node.Args, _queryAlias);
 
             if (!InferredColumns.ContainsKey(aliasedSchemaFromNode))
                 InferredColumns.Add(aliasedSchemaFromNode, table.Columns);
+
+            if (!_usedColumns.ContainsKey(_queryAlias))
+                _usedColumns.Add(_queryAlias, new List<ISchemaColumn>());
 
             Nodes.Push(aliasedSchemaFromNode);
         }
@@ -538,7 +551,7 @@ namespace Musoq.Evaluator.Visitors
             var b = (FromNode) Nodes.Pop();
             var a = (FromNode) Nodes.Pop();
 
-            Nodes.Push(new JoinSourcesTableFromNode(a, b, exp, node.JoinType));
+            Nodes.Push(new Parser.JoinSourcesTableFromNode(a, b, exp, node.JoinType));
         }
 
         public void Visit(InMemoryTableFromNode node)
@@ -565,7 +578,7 @@ namespace Musoq.Evaluator.Visitors
                 new TableSymbol(_queryAlias, tableSchemaPair.Schema, tableSchemaPair.Table, node.Alias == _queryAlias));
             _currentScope[node.Id] = _queryAlias;
 
-            Nodes.Push(new InMemoryTableFromNode(node.VariableName, _queryAlias));
+            Nodes.Push(new Parser.InMemoryTableFromNode(node.VariableName, _queryAlias));
         }
 
         public void Visit(JoinFromNode node)
@@ -573,7 +586,7 @@ namespace Musoq.Evaluator.Visitors
             var expression = Nodes.Pop();
             var joinedTable = (FromNode) Nodes.Pop();
             var source = (FromNode) Nodes.Pop();
-            var joinedFrom = new JoinFromNode(source, joinedTable, expression, node.JoinType);
+            var joinedFrom = new Parser.JoinFromNode(source, joinedTable, expression, node.JoinType);
             _identifier = joinedFrom.Alias;
             _schemaFromArgs.Clear();
             Nodes.Push(joinedFrom);
@@ -583,7 +596,7 @@ namespace Musoq.Evaluator.Visitors
         {
             var from = (FromNode) Nodes.Pop();
             _identifier = from.Alias;
-            Nodes.Push(new ExpressionFromNode(from));
+            Nodes.Push(new Parser.ExpressionFromNode(from));
 
             var tableSymbol = _currentScope.ScopeSymbolTable.GetSymbol<TableSymbol>(_identifier);
 
@@ -663,7 +676,7 @@ namespace Musoq.Evaluator.Visitors
         {
             var exp = Nodes.Pop();
             var from = (FromNode) Nodes.Pop();
-            Nodes.Push(new JoinInMemoryWithSourceTableFromNode(node.InMemoryTableAlias, from, exp, node.JoinType));
+            Nodes.Push(new Parser.JoinInMemoryWithSourceTableFromNode(node.InMemoryTableAlias, from, exp, node.JoinType));
         }
 
         public void Visit(InternalQueryNode node)
@@ -812,7 +825,7 @@ namespace Musoq.Evaluator.Visitors
         public void Visit(JoinsNode node)
         {
             _identifier = node.Alias;
-            Nodes.Push(new JoinsNode((JoinFromNode) Nodes.Pop()));
+            Nodes.Push(new Parser.JoinsNode((Parser.JoinFromNode) Nodes.Pop()));
         }
 
         public void Visit(JoinNode node)
@@ -963,6 +976,9 @@ namespace Musoq.Evaluator.Visitors
             {
                 accessMethod = func(node.FToken, args, new ArgsListNode(Array.Empty<Node>()), method, alias, canSkipInjectSource);
             }
+            
+            if (method.DeclaringType == null)
+                throw new InvalidOperationException("Method must have a declaring type.");
 
             AddAssembly(method.DeclaringType.Assembly);
             AddAssembly(method.ReturnType.Assembly);
@@ -1012,16 +1028,16 @@ namespace Musoq.Evaluator.Visitors
 
             for (int i = 0; i < node.TableTypePairs.Length; i++)
             {
-                (string ColumnName, string TypeName) = node.TableTypePairs[i];
+                (string columnName, string typeName) = node.TableTypePairs[i];
 
-                var remappedType = EvaluationHelper.RemapPrimitiveTypes(TypeName);
+                var remappedType = EvaluationHelper.RemapPrimitiveTypes(typeName);
 
                 var type = EvaluationHelper.GetType(remappedType);
 
                 if (type == null)
                     throw new TypeNotFoundException($"Type '{remappedType}' could not be found.");
 
-                columns.Add(new SchemaColumn(ColumnName, i, type));
+                columns.Add(new SchemaColumn(columnName, i, type));
             }
 
             var table = new DynamicTable(columns.ToArray());
@@ -1082,6 +1098,33 @@ namespace Musoq.Evaluator.Visitors
                 throw new FieldLinkIndexOutOfRangeException(index, _groupByFields.Count);
 
             Nodes.Push(_groupByFields[index].Expression);
+        }
+
+        private static void PrepareAndThrowUnknownColumnExceptionMessage(string identifier, ISchemaColumn[] columns)
+        {
+            var library = new TransitionLibrary();
+            var candidates = new StringBuilder();
+
+            var candidatesColumns = columns.Where(
+                col => 
+                    library.Soundex(col.ColumnName) == library.Soundex(identifier) ||
+                    library.LevenshteinDistance(col.ColumnName, identifier).Value < 3).ToArray();
+
+            for (int i = 0; i < candidatesColumns.Length - 1; i++)
+            {
+                ISchemaColumn candidate = candidatesColumns[i];
+                candidates.Append(candidate.ColumnName);
+                candidates.Append(", ");
+            }
+
+            if (candidatesColumns.Length > 0)
+            {
+                candidates.Append(candidatesColumns[^1].ColumnName);
+
+                throw new UnknownColumnException($"Column '{identifier}' could not be found. Did you mean to use [{candidates.ToString()}]?");
+            }
+
+            throw new UnknownColumnException($"Column {identifier} could not be found.");
         }
     }
 }

--- a/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
+++ b/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {
@@ -321,7 +322,7 @@ namespace Musoq.Evaluator.Visitors
 
         public virtual void Visit(SchemaFromNode node)
         {
-            Nodes.Push(new SchemaFromNode(node.Schema, node.Method, (ArgsListNode)Nodes.Pop(), node.Alias));
+            Nodes.Push(new Parser.SchemaFromNode(node.Schema, node.Method, (ArgsListNode)Nodes.Pop(), node.Alias));
         }
 
         public virtual void Visit(JoinSourcesTableFromNode node)
@@ -330,12 +331,12 @@ namespace Musoq.Evaluator.Visitors
             var b = (FromNode) Nodes.Pop();
             var a = (FromNode) Nodes.Pop();
 
-            Nodes.Push(new JoinSourcesTableFromNode(a, b, exp, node.JoinType));
+            Nodes.Push(new Parser.JoinSourcesTableFromNode(a, b, exp, node.JoinType));
         }
 
         public virtual void Visit(InMemoryTableFromNode node)
         {
-            Nodes.Push(new InMemoryTableFromNode(node.VariableName, node.Alias));
+            Nodes.Push(new Parser.InMemoryTableFromNode(node.VariableName, node.Alias));
         }
 
         public virtual void Visit(JoinFromNode node)
@@ -343,14 +344,14 @@ namespace Musoq.Evaluator.Visitors
             var expression = Nodes.Pop();
             var joinedTable = (FromNode) Nodes.Pop();
             var source = (FromNode) Nodes.Pop();
-            var joinedFrom = new JoinFromNode(source, joinedTable, expression, node.JoinType);
+            var joinedFrom = new Parser.JoinFromNode(source, joinedTable, expression, node.JoinType);
             Nodes.Push(joinedFrom);
         }
 
         public virtual void Visit(ExpressionFromNode node)
         {
             var from = (FromNode) Nodes.Pop();
-            Nodes.Push(new ExpressionFromNode(from));
+            Nodes.Push(new Parser.ExpressionFromNode(from));
         }
 
         public virtual void Visit(CreateTransformationTableNode node)
@@ -409,7 +410,7 @@ namespace Musoq.Evaluator.Visitors
         {
             var exp = Nodes.Pop();
             var from = (FromNode) Nodes.Pop();
-            Nodes.Push(new JoinInMemoryWithSourceTableFromNode(node.InMemoryTableAlias, from, exp, node.JoinType));
+            Nodes.Push(new Parser.JoinInMemoryWithSourceTableFromNode(node.InMemoryTableAlias, from, exp, node.JoinType));
         }
 
         public virtual void Visit(InternalQueryNode node)
@@ -495,7 +496,7 @@ namespace Musoq.Evaluator.Visitors
 
         public virtual void Visit(JoinsNode node)
         {
-            Nodes.Push(new JoinsNode((JoinFromNode) Nodes.Pop()));
+            Nodes.Push(new Parser.JoinsNode((Parser.JoinFromNode) Nodes.Pop()));
         }
 
         public virtual void Visit(JoinNode node)
@@ -531,12 +532,12 @@ namespace Musoq.Evaluator.Visitors
 
         public void Visit(AliasedFromNode node)
         {
-            Nodes.Push(new AliasedFromNode(node.Identifier, node.Args, node.Alias));
+            Nodes.Push(new Parser.AliasedFromNode(node.Identifier, node.Args, node.Alias));
         }
 
         public void Visit(SchemaMethodFromNode node)
         {
-            Nodes.Push(new SchemaMethodFromNode(node.Schema, node.Method));
+            Nodes.Push(new Parser.SchemaMethodFromNode(node.Schema, node.Method));
         }
 
         public void Visit(StatementsArrayNode node)

--- a/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
+++ b/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
@@ -135,14 +135,14 @@ namespace Musoq.Evaluator.Visitors
             Nodes.Push(new LikeNode(left, right));
         }
 
-        public void Visit(RLikeNode node)
+        public virtual void Visit(RLikeNode node)
         {
             var right = Nodes.Pop();
             var left = Nodes.Pop();
             Nodes.Push(new RLikeNode(left, right));
         }
 
-        public void Visit(InNode node)
+        public virtual void Visit(InNode node)
         {
             var right = Nodes.Pop();
             var left = Nodes.Pop();

--- a/Musoq.Evaluator/Visitors/GetSelectFieldsTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/GetSelectFieldsTraverseVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {

--- a/Musoq.Evaluator/Visitors/GetSelectFieldsVisitor.cs
+++ b/Musoq.Evaluator/Visitors/GetSelectFieldsVisitor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 using Musoq.Schema;
 using Musoq.Schema.DataSources;
 

--- a/Musoq.Evaluator/Visitors/RawTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/RawTraverseVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {

--- a/Musoq.Evaluator/Visitors/RewriteFieldWithGroupMethodCall.cs
+++ b/Musoq.Evaluator/Visitors/RewriteFieldWithGroupMethodCall.cs
@@ -48,7 +48,7 @@ namespace Musoq.Evaluator.Visitors
 
         public override void Visit(AccessMethodNode node)
         {
-            if (node.IsAggregateMethod)
+            if (node.IsAggregateMethod())
             {
                 Nodes.Pop();
 

--- a/Musoq.Evaluator/Visitors/RewriteQueryTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/RewriteQueryTraverseVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Musoq.Evaluator.Utils;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {

--- a/Musoq.Evaluator/Visitors/RewriteWhereExpressionToPassItToDataSourceTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/RewriteWhereExpressionToPassItToDataSourceTraverseVisitor.cs
@@ -1,0 +1,11 @@
+﻿using Musoq.Parser;
+
+namespace Musoq.Evaluator.Visitors;
+
+public class RewriteWhereExpressionToPassItToDataSourceTraverseVisitor : CloneTraverseVisitor
+{
+    public RewriteWhereExpressionToPassItToDataSourceTraverseVisitor(IExpressionVisitor visitor) 
+        : base(visitor)
+    {
+    }
+}

--- a/Musoq.Evaluator/Visitors/RewriteWhereExpressionToPassItToDataSourceVisitor.cs
+++ b/Musoq.Evaluator/Visitors/RewriteWhereExpressionToPassItToDataSourceVisitor.cs
@@ -1,0 +1,212 @@
+using Musoq.Parser;
+using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
+
+namespace Musoq.Evaluator.Visitors;
+
+public class RewriteWhereExpressionToPassItToDataSourceVisitor : CloneQueryVisitor
+{
+    private readonly SchemaFromNode _schemaFromNode;
+    private readonly Node _equalityNode;
+    
+    public WhereNode WhereNode => (WhereNode) Nodes.Peek();
+
+    public RewriteWhereExpressionToPassItToDataSourceVisitor(SchemaFromNode schemaFromNode)
+    {
+        _schemaFromNode = schemaFromNode;
+        _equalityNode = new EqualityNode(new IntegerNode("1"), new IntegerNode("1"));
+    }
+
+    public override void Visit(GreaterNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new GreaterNode(left, right));
+        }
+    }
+    
+    public override void Visit(GreaterOrEqualNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new GreaterOrEqualNode(left, right));
+        }
+    }
+    
+    public override void Visit(LessNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new LessNode(left, right));
+        }
+    }
+    
+    public override void Visit(LessOrEqualNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new LessOrEqualNode(left, right));
+        }
+    }
+
+    public override void Visit(EqualityNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new EqualityNode(left, right));
+        }
+    }
+    
+    public override void Visit(DiffNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForBinaryNode(node))
+        {
+            Nodes.Push(new DiffNode(left, right));
+        }
+    }
+
+    public override void Visit(LikeNode node)
+    {
+        Nodes.Pop();
+        Nodes.Pop();
+        
+        Nodes.Push(_equalityNode);
+    }
+
+    public override void Visit(RLikeNode node)
+    {
+        Nodes.Pop();
+        Nodes.Pop();
+        
+        Nodes.Push(_equalityNode);
+    }
+
+    public override void Visit(ContainsNode node)
+    {
+        var right = Nodes.Pop();
+        var left = Nodes.Pop();
+
+        if (!VisitForArgsListNode(node.ToCompareExpression))
+        {
+            Nodes.Push(new ContainsNode(left, (ArgsListNode)right));
+        }
+    }
+
+    public override void Visit(InNode node)
+    {
+        var clonedNode = Nodes.Pop();
+
+        if (!VisitForArgsListNode((ArgsListNode)node.Right))
+        {
+            Nodes.Push(clonedNode);
+        }
+    }
+
+    private bool VisitForBinaryNode(BinaryNode node)
+    {
+        var isComplexVisitor = new IsComplexVisitor(_schemaFromNode.Alias);
+        var isComplexTraverseVisitor = new IsComplexTraverseVisitor(isComplexVisitor);
+        
+        node.Left.Accept(isComplexTraverseVisitor);
+        var leftIsComplex = isComplexVisitor.IsComplex;
+        
+        isComplexVisitor.Reset();
+        
+        node.Right.Accept(isComplexTraverseVisitor);
+        var rightIsComplex = isComplexVisitor.IsComplex;
+
+        if (leftIsComplex || rightIsComplex)
+        {
+            Nodes.Push(_equalityNode);
+            return true;
+        }
+        
+        return false;
+    }
+
+    private bool VisitForArgsListNode(ArgsListNode node)
+    {
+        var isComplexVisitor = new IsComplexVisitor(_schemaFromNode.Alias);
+        var isComplexTraverseVisitor = new IsComplexTraverseVisitor(isComplexVisitor);
+        var isComplex = false;
+        foreach (var argument in node.Args)
+        {
+            argument.Accept(isComplexTraverseVisitor);
+            isComplex |= isComplexVisitor.IsComplex;
+            isComplexVisitor.Reset();
+        }
+
+        if (isComplex)
+        {
+            Nodes.Push(_equalityNode);
+            return true;
+        }
+        
+        return false;
+    }
+    
+    private class IsComplexTraverseVisitor : CloneTraverseVisitor
+    {
+        public IsComplexTraverseVisitor(IExpressionVisitor visitor) 
+            : base(visitor)
+        {
+        }
+    }
+    
+    private class IsComplexVisitor : CloneQueryVisitor
+    {
+        private readonly string _rootAlias;
+
+        public IsComplexVisitor(string rootAlias)
+        {
+            _rootAlias = rootAlias;
+        }
+
+        public bool IsComplex { get; private set; }
+
+        public void Reset()
+        {
+            IsComplex = false;
+        }
+        
+        public override void Visit(AccessMethodNode node)
+        {
+            IsComplex = true;
+            
+            base.Visit(node);
+        }
+        
+        public override void Visit(AccessCallChainNode node)
+        {
+            IsComplex = true;
+            
+            base.Visit(node);
+        }
+        
+        public override void Visit(AccessColumnNode node)
+        {
+            if (node.Alias != _rootAlias)
+                IsComplex = true;
+            
+            base.Visit(node);
+        }
+    }
+}

--- a/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeTraverseVisitor.cs
+++ b/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeTraverseVisitor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Musoq.Evaluator.Utils;
 using Musoq.Parser;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Evaluator.Visitors
 {

--- a/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeVisitor.cs
+++ b/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeVisitor.cs
@@ -61,7 +61,7 @@ namespace Musoq.Evaluator.Visitors
 
         public ToCSharpRewriteTreeVisitor(
             IEnumerable<Assembly> assemblies,
-            IDictionary<string, int[]> setOperatorFieldIndexes, 
+            IDictionary<string, int[]> setOperatorFieldIndexes,
             IDictionary<SchemaFromNode, ISchemaColumn[]> inferredColumns,
             string assemblyName)
         {
@@ -78,7 +78,8 @@ namespace Musoq.Evaluator.Visitors
 
             var env = new Plugins.Environment();
             Compilation = Compilation
-                .AddReferences(MetadataReference.CreateFromFile(env.Value<string>(Constants.NetStandardDllEnvironmentName)));
+                .AddReferences(
+                    MetadataReference.CreateFromFile(env.Value<string>(Constants.NetStandardDllEnvironmentName)));
 
             AddReference(typeof(object));
             AddReference(typeof(CancellationToken));
@@ -111,12 +112,14 @@ namespace Musoq.Evaluator.Visitors
             AddNamespace("Musoq.Schema");
             AddNamespace("Musoq.Evaluator");
             AddNamespace("Musoq.Parser.Nodes.From");
+            AddNamespace("Musoq.Parser.Nodes");
             AddNamespace("Musoq.Evaluator.Tables");
             AddNamespace("Musoq.Evaluator.Helpers");
             AddNamespace("System.Dynamic");
         }
 
-        public string Namespace { get; } = $"{Resources.Compilation.NamespaceConstantPart}_{StringHelpers.GenerateNamespaceIdentifier()}";
+        public string Namespace { get; } =
+            $"{Resources.Compilation.NamespaceConstantPart}_{StringHelpers.GenerateNamespaceIdentifier()}";
 
         public string ClassName { get; } = "CompiledQuery";
 
@@ -142,7 +145,7 @@ namespace Musoq.Evaluator.Visitors
         {
             AddNamespace(typeof(EvaluationHelper).Namespace);
 
-            switch(node.Type)
+            switch (node.Type)
             {
                 case DescForType.Constructors:
                     CreateDescForConstructors(node);
@@ -197,15 +200,17 @@ namespace Musoq.Evaluator.Visitors
                     .WithArgumentList(
                         SyntaxFactory.ArgumentList(
                             SyntaxFactory.SeparatedList(
-                                new[] {
+                                new[]
+                                {
                                     SyntaxFactory.Argument(SyntaxFactory.IdentifierName("desc")),
-                                    SyntaxHelper.StringLiteralArgument(((SchemaFromNode)node.From).Method)
+                                    SyntaxHelper.StringLiteralArgument(((SchemaFromNode) node.From).Method)
                                 }))), false);
         }
 
-        private void CreateDescMethod(DescNode node, InvocationExpressionSyntax invocationExpression, bool useProvidedTable)
+        private void CreateDescMethod(DescNode node, InvocationExpressionSyntax invocationExpression,
+            bool useProvidedTable)
         {
-            var schemaNode = (SchemaFromNode)node.From;
+            var schemaNode = (SchemaFromNode) node.From;
             var createdSchema = SyntaxHelper.CreateAssignmentByMethodCall(
                 "desc",
                 "provider",
@@ -222,7 +227,8 @@ namespace Musoq.Evaluator.Visitors
 
             if (useProvidedTable)
             {
-                var args = schemaNode.Parameters.Args.Select(arg => (ExpressionSyntax)Generator.LiteralExpression(((ConstantValueNode)arg).ObjValue)).ToArray();
+                var args = schemaNode.Parameters.Args.Select(arg =>
+                    (ExpressionSyntax) Generator.LiteralExpression(((ConstantValueNode) arg).ObjValue)).ToArray();
 
                 var gettedTable = SyntaxHelper.CreateAssignmentByMethodCall(
                     "schemaTable",
@@ -279,7 +285,7 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.IdentifierName(nameof(ISchemaProvider))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("provider"), null),
-                        
+
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxTokenList.Create(
@@ -289,7 +295,8 @@ namespace Musoq.Evaluator.Visitors
                                 .WithTypeArgumentList(
                                     SyntaxFactory.TypeArgumentList(
                                         SyntaxFactory.SeparatedList<TypeSyntax>(
-                                            new SyntaxNodeOrToken[]{
+                                            new SyntaxNodeOrToken[]
+                                            {
                                                 SyntaxFactory.PredefinedType(
                                                     SyntaxFactory.Token(SyntaxKind.UIntKeyword)),
                                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
@@ -298,44 +305,61 @@ namespace Musoq.Evaluator.Visitors
                                                     .WithTypeArgumentList(
                                                         SyntaxFactory.TypeArgumentList(
                                                             SyntaxFactory.SeparatedList<TypeSyntax>(
-                                                                new SyntaxNodeOrToken[]{
+                                                                new SyntaxNodeOrToken[]
+                                                                {
                                                                     SyntaxFactory.PredefinedType(
                                                                         SyntaxFactory.Token(SyntaxKind.StringKeyword)),
                                                                     SyntaxFactory.Token(SyntaxKind.CommaToken),
                                                                     SyntaxFactory.PredefinedType(
-                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))})))})))
+                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))
+                                                                })))
+                                            })))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("positionalEnvironmentVariables"), null),
-                        
+
                         SyntaxFactory.Parameter(
-                            SyntaxFactory.Identifier("queriesInformation"))
-                        .WithType(
-                            SyntaxFactory.GenericName(
-                                SyntaxFactory.Identifier("IReadOnlyDictionary"))
-                            .WithTypeArgumentList(
-                                SyntaxFactory.TypeArgumentList(
-                                    SyntaxFactory.SeparatedList<TypeSyntax>(
-                                        new SyntaxNodeOrToken[]{
-                                            SyntaxFactory.PredefinedType(
-                                                SyntaxFactory.Token(SyntaxKind.StringKeyword)),
-                                            SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                            SyntaxFactory.TupleType(
-                                                SyntaxFactory.SeparatedList<TupleElementSyntax>(
-                                                    new SyntaxNodeOrToken[]{
-                                                        SyntaxFactory.TupleElement(
-                                                            SyntaxFactory.IdentifierName("SchemaFromNode"))
-                                                        .WithIdentifier(
-                                                            SyntaxFactory.Identifier("FromNode")),
-                                                        SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                                        SyntaxFactory.TupleElement(
-                                                            SyntaxFactory.GenericName(
-                                                                SyntaxFactory.Identifier("IReadOnlyCollection"))
-                                                            .WithTypeArgumentList(
-                                                                SyntaxFactory.TypeArgumentList(
-                                                                    SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
-                                                                        SyntaxFactory.IdentifierName("ISchemaColumn")))))
-                                                        .WithIdentifier(
-                                                            SyntaxFactory.Identifier("UsedColumns"))}))})))),
+                                SyntaxFactory.Identifier("queriesInformation"))
+                            .WithType(
+                                SyntaxFactory.GenericName(
+                                        SyntaxFactory.Identifier("IReadOnlyDictionary"))
+                                    .WithTypeArgumentList(
+                                        SyntaxFactory.TypeArgumentList(
+                                            SyntaxFactory.SeparatedList<TypeSyntax>(
+                                                new SyntaxNodeOrToken[]
+                                                {
+                                                    SyntaxFactory.PredefinedType(
+                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                                                    SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                    SyntaxFactory.TupleType(
+                                                        SyntaxFactory.SeparatedList<TupleElementSyntax>(
+                                                            new SyntaxNodeOrToken[]
+                                                            {
+                                                                SyntaxFactory.TupleElement(
+                                                                        SyntaxFactory.IdentifierName("SchemaFromNode"))
+                                                                    .WithIdentifier(
+                                                                        SyntaxFactory.Identifier("FromNode")),
+                                                                SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                SyntaxFactory.TupleElement(
+                                                                        SyntaxFactory.GenericName(
+                                                                                SyntaxFactory.Identifier(
+                                                                                    "IReadOnlyCollection"))
+                                                                            .WithTypeArgumentList(
+                                                                                SyntaxFactory.TypeArgumentList(
+                                                                                    SyntaxFactory
+                                                                                        .SingletonSeparatedList<
+                                                                                            TypeSyntax>(
+                                                                                            SyntaxFactory
+                                                                                                .IdentifierName(
+                                                                                                    "ISchemaColumn")))))
+                                                                    .WithIdentifier(
+                                                                        SyntaxFactory.Identifier("UsedColumns")),
+                                                                SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                SyntaxFactory.TupleElement(
+                                                                        SyntaxFactory.IdentifierName("WhereNode"))
+                                                                    .WithIdentifier(
+                                                                        SyntaxFactory.Identifier("WhereNode"))
+                                                            }))
+                                                })))),
 
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
@@ -518,7 +542,7 @@ namespace Musoq.Evaluator.Visitors
 
             Visit(new AccessMethodNode(
                 new FunctionToken(nameof(Operators.RLike), TextSpan.Empty),
-                new ArgsListNode(new[] { node.Left, node.Right }), null, false,
+                new ArgsListNode(new[] {node.Left, node.Right}), null, false,
                 typeof(Operators).GetMethod(nameof(Operators.RLike))));
         }
 
@@ -556,7 +580,7 @@ namespace Musoq.Evaluator.Visitors
             AddNamespace(types);
 
             var typeIdentifier = SyntaxFactory.IdentifierName(
-                    EvaluationHelper.GetCastableType(node.ReturnType));
+                EvaluationHelper.GetCastableType(node.ReturnType));
 
             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(node.ReturnType))
             {
@@ -573,7 +597,7 @@ namespace Musoq.Evaluator.Visitors
         {
             Nodes.Push(
                 SyntaxFactory.LiteralExpression(
-                    SyntaxKind.StringLiteralExpression, 
+                    SyntaxKind.StringLiteralExpression,
                     SyntaxFactory.Literal($"@\"{node.Value}\"", node.Value)));
         }
 
@@ -678,14 +702,16 @@ namespace Musoq.Evaluator.Visitors
                         }
 
                         var typeIdentifier = SyntaxFactory.IdentifierName(
-                                        EvaluationHelper.GetCastableType(parameterInfo.ParameterType));
+                            EvaluationHelper.GetCastableType(parameterInfo.ParameterType));
 
                         if (parameterInfo.ParameterType == typeof(ExpandoObject))
                         {
                             typeIdentifier = SyntaxFactory.IdentifierName("dynamic");
                         }
 
-                        var aliases = _scope.Parent.ScopeSymbolTable.GetSymbol<AliasesPositionsSymbol>(MetaAttributes.AllQueryContexts);
+                        var aliases =
+                            _scope.Parent.ScopeSymbolTable.GetSymbol<AliasesPositionsSymbol>(MetaAttributes
+                                .AllQueryContexts);
                         var currentContext = aliases.AliasesPositions[node.Alias];
 
                         args.Add(
@@ -694,16 +720,18 @@ namespace Musoq.Evaluator.Visitors
                                     typeIdentifier,
                                     SyntaxFactory.ElementAccessExpression(
                                         SyntaxFactory.MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        SyntaxFactory.IdentifierName(objectName),
-                                        SyntaxFactory.IdentifierName(nameof(IObjectResolver.Contexts))),
-                                    SyntaxFactory.BracketedArgumentList(
-                                        SyntaxFactory.SeparatedList(
-                                            new[] 
-                                            {
-                                                SyntaxFactory.Argument(
-                                                    SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(currentContext)))
-                                            }))))));
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            SyntaxFactory.IdentifierName(objectName),
+                                            SyntaxFactory.IdentifierName(nameof(IObjectResolver.Contexts))),
+                                        SyntaxFactory.BracketedArgumentList(
+                                            SyntaxFactory.SeparatedList(
+                                                new[]
+                                                {
+                                                    SyntaxFactory.Argument(
+                                                        SyntaxFactory.LiteralExpression(
+                                                            SyntaxKind.NumericLiteralExpression,
+                                                            SyntaxFactory.Literal(currentContext)))
+                                                }))))));
                         break;
                     case InjectGroupAttribute _:
 
@@ -742,7 +770,7 @@ namespace Musoq.Evaluator.Visitors
                 var genericArgs = node.Method.GetGenericArguments();
                 var syntaxArgs = new List<SyntaxNodeOrToken>();
 
-                for(int i = 0; i < genericArgs.Length - 1; ++i)
+                for (int i = 0; i < genericArgs.Length - 1; ++i)
                 {
                     syntaxArgs.Add(SyntaxFactory.IdentifierName(genericArgs[i].FullName));
                     syntaxArgs.Add(SyntaxFactory.Token(SyntaxKind.CommaToken));
@@ -755,7 +783,7 @@ namespace Musoq.Evaluator.Visitors
                 {
                     typeArgs = SyntaxFactory.TypeArgumentList(
                         SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
-                            (IdentifierNameSyntax)syntaxArgs[0]));
+                            (IdentifierNameSyntax) syntaxArgs[0]));
                 }
                 else
                 {
@@ -768,10 +796,10 @@ namespace Musoq.Evaluator.Visitors
                     .GenericName(node.Name)
                     .WithTypeArgumentList(
                         typeArgs
-                        .WithLessThanToken(
-                            SyntaxFactory.Token(SyntaxKind.LessThanToken))
-                        .WithGreaterThanToken(
-                            SyntaxFactory.Token(SyntaxKind.GreaterThanToken)));
+                            .WithLessThanToken(
+                                SyntaxFactory.Token(SyntaxKind.LessThanToken))
+                            .WithGreaterThanToken(
+                                SyntaxFactory.Token(SyntaxKind.GreaterThanToken)));
 
                 accessMethodExpr = Generator.InvocationExpression(
                     Generator.MemberAccessExpression(
@@ -805,7 +833,9 @@ namespace Musoq.Evaluator.Visitors
             {
                 Nodes.Pop();
                 Nodes.Push(
-                    node.IsNegated ? SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression) : SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression));
+                    node.IsNegated
+                        ? SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)
+                        : SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression));
                 return;
             }
 
@@ -819,7 +849,7 @@ namespace Musoq.Evaluator.Visitors
                 Nodes.Push(
                     SyntaxFactory.BinaryExpression(
                         SyntaxKind.EqualsExpression,
-                        (ExpressionSyntax)Nodes.Pop(),
+                        (ExpressionSyntax) Nodes.Pop(),
                         SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
         }
 
@@ -847,7 +877,7 @@ namespace Musoq.Evaluator.Visitors
                 Generator.IdentifierName(variableName),
                 SyntaxFactory.Argument(
                     SyntaxFactory.LiteralExpression(
-                        SyntaxKind.StringLiteralExpression, 
+                        SyntaxKind.StringLiteralExpression,
                         SyntaxFactory.Literal($"@\"{node.Name}\"", node.Name))));
 
             var types = EvaluationHelper.GetNestedTypes(node.ReturnType);
@@ -883,9 +913,9 @@ namespace Musoq.Evaluator.Visitors
                     SyntaxFactory.BracketedArgumentList(
                         SyntaxFactory.SingletonSeparatedList(
                             SyntaxFactory.Argument(
-                            SyntaxFactory.LiteralExpression(
-                                SyntaxKind.NumericLiteralExpression,
-                                SyntaxFactory.Literal(_inMemoryTableIndexes[node.Name])))))));
+                                SyntaxFactory.LiteralExpression(
+                                    SyntaxKind.NumericLiteralExpression,
+                                    SyntaxFactory.Literal(_inMemoryTableIndexes[node.Name])))))));
         }
 
         public void Visit(AccessObjectArrayNode node)
@@ -1035,14 +1065,14 @@ namespace Musoq.Evaluator.Visitors
 
         public void Visit(WhereNode node)
         {
-            var ifStatement = 
+            var ifStatement =
                 Generator.IfStatement(
                         Generator.LogicalNotExpression(Nodes.Pop()),
                         new SyntaxNode[]
                         {
                             SyntaxFactory.ContinueStatement()
                         })
-                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+                    .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
             NullSuspiciousNodes.Clear();
             Nodes.Push(ifStatement);
@@ -1097,7 +1127,8 @@ namespace Musoq.Evaluator.Visitors
                 fieldNames.Append(',');
             }
 
-            fieldName = $"new string[]{{{groupFields.Names.Select(f => $"@\"{f}\"").Aggregate((a, b) => a + "," + b)}}}";
+            fieldName =
+                $"new string[]{{{groupFields.Names.Select(f => $"@\"{f}\"").Aggregate((a, b) => a + "," + b)}}}";
             fieldNames.Append(fieldName);
             fieldNames.Append("};");
 
@@ -1194,19 +1225,20 @@ namespace Musoq.Evaluator.Visitors
                                         SyntaxFactory.IdentifierName($"{node.SourceTable.Alias}Rows.Rows"),
                                         SyntaxFactory.Block(
                                             GenerateCancellationExpression(),
-                                            (StatementSyntax)ifStatement,
+                                            (StatementSyntax) ifStatement,
                                             _emptyBlock))))));
                     break;
                 case JoinType.OuterLeft:
 
                     var fullTransitionTable = _scope.ScopeSymbolTable.GetSymbol<TableSymbol>(_queryAlias);
-                    var fieldNames = _scope.ScopeSymbolTable.GetSymbol<FieldsNamesSymbol>(MetaAttributes.OuterJoinSelect);
+                    var fieldNames =
+                        _scope.ScopeSymbolTable.GetSymbol<FieldsNamesSymbol>(MetaAttributes.OuterJoinSelect);
                     var expressions = new List<ExpressionSyntax>();
 
                     int j = 0;
                     for (int i = 0; i < fullTransitionTable.CompoundTables.Length - 1; i++)
                     {
-                        foreach(var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[i]))
+                        foreach (var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[i]))
                         {
                             expressions.Add(
                                 SyntaxFactory.ElementAccessExpression(
@@ -1214,27 +1246,29 @@ namespace Musoq.Evaluator.Visitors
                                     SyntaxFactory.BracketedArgumentList(
                                         SyntaxFactory.SingletonSeparatedList(
                                             SyntaxFactory.Argument(
-                                                (LiteralExpressionSyntax)Generator.LiteralExpression(fieldNames.Names[j]))))));
+                                                (LiteralExpressionSyntax) Generator.LiteralExpression(
+                                                    fieldNames.Names[j]))))));
 
                             j += 1;
                         }
                     }
 
-                    foreach (var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[fullTransitionTable.CompoundTables.Length - 1]))
+                    foreach (var column in fullTransitionTable.GetColumns(
+                                 fullTransitionTable.CompoundTables[fullTransitionTable.CompoundTables.Length - 1]))
                     {
                         expressions.Add(
                             SyntaxFactory.CastExpression(
                                 SyntaxFactory.IdentifierName(
                                     EvaluationHelper.GetCastableType(column.ColumnType)),
-                                (LiteralExpressionSyntax)Generator.NullLiteralExpression()));
+                                (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                     }
 
                     var arrayType = SyntaxFactory.ArrayType(
-                                        SyntaxFactory.IdentifierName("object"),
-                                        new SyntaxList<ArrayRankSpecifierSyntax>(
-                                            SyntaxFactory.ArrayRankSpecifier(
-                                            SyntaxFactory.SingletonSeparatedList(
-                                                (ExpressionSyntax)SyntaxFactory.OmittedArraySizeExpression()))));
+                        SyntaxFactory.IdentifierName("object"),
+                        new SyntaxList<ArrayRankSpecifierSyntax>(
+                            SyntaxFactory.ArrayRankSpecifier(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    (ExpressionSyntax) SyntaxFactory.OmittedArraySizeExpression()))));
 
                     var rewriteSelect =
                         SyntaxFactory.VariableDeclaration(
@@ -1251,7 +1285,6 @@ namespace Musoq.Evaluator.Visitors
                                                 SyntaxFactory.SeparatedList(expressions)))))));
 
 
-
                     var invocation = SyntaxHelper.CreateMethodInvocation(
                         _scope[MetaAttributes.SelectIntoVariableName],
                         nameof(Table.Add),
@@ -1259,7 +1292,8 @@ namespace Musoq.Evaluator.Visitors
                         {
                             SyntaxFactory.Argument(
                                 SyntaxFactory.ObjectCreationExpression(
-                                    SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxHelper.WhiteSpace),
+                                    SyntaxFactory.Token(SyntaxKind.NewKeyword)
+                                        .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                                     SyntaxFactory.ParseTypeName(nameof(ObjectsRow)),
                                     SyntaxFactory.ArgumentList(
                                         SyntaxFactory.SeparatedList(
@@ -1268,15 +1302,17 @@ namespace Musoq.Evaluator.Visitors
                                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("select")),
                                                 SyntaxFactory.Argument(
                                                     SyntaxFactory.MemberAccessExpression(
-                                                        SyntaxKind.SimpleMemberAccessExpression, 
+                                                        SyntaxKind.SimpleMemberAccessExpression,
                                                         SyntaxFactory.IdentifierName($"{node.InMemoryTableAlias}Row"),
-                                                        SyntaxFactory.IdentifierName($"{nameof(IObjectResolver.Contexts)}"))),
+                                                        SyntaxFactory.IdentifierName(
+                                                            $"{nameof(IObjectResolver.Contexts)}"))),
                                                 SyntaxFactory.Argument(
-                                                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
+                                                    SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
                                             })
                                     ),
                                     SyntaxFactory.InitializerExpression(SyntaxKind.ComplexElementInitializerExpression))
-                            )});
+                            )
+                        });
 
                     computingBlock = computingBlock.AddStatements(
                         SyntaxFactory.ForEachStatement(
@@ -1286,25 +1322,29 @@ namespace Musoq.Evaluator.Visitors
                                 $"{nameof(EvaluationHelper)}.{nameof(EvaluationHelper.ConvertTableToSource)}({node.InMemoryTableAlias}TransitionTable).{nameof(RowSource.Rows)}"),
                             SyntaxFactory.Block(
                                 SyntaxFactory.LocalDeclarationStatement(
-                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched", SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))),
+                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched",
+                                        SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))),
                                 SyntaxFactory.ForEachStatement(
-                                        SyntaxFactory.IdentifierName("var"),
-                                        SyntaxFactory.Identifier($"{node.SourceTable.Alias}Row"),
-                                        SyntaxFactory.IdentifierName($"{node.SourceTable.Alias}Rows.Rows"),
-                                        SyntaxFactory.Block(
-                                            GenerateCancellationExpression(),
-                                            (StatementSyntax)ifStatement,
-                                            _emptyBlock,
-                                            SyntaxFactory.IfStatement(
-                                                (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                                SyntaxFactory.Block(
-                                                    SyntaxFactory.ExpressionStatement(
-                                                        SyntaxFactory.AssignmentExpression(
-                                                            SyntaxKind.SimpleAssignmentExpression, 
-                                                            SyntaxFactory.IdentifierName("hasAnyRowMatched"), 
-                                                            (LiteralExpressionSyntax) Generator.TrueLiteralExpression())))))),
+                                    SyntaxFactory.IdentifierName("var"),
+                                    SyntaxFactory.Identifier($"{node.SourceTable.Alias}Row"),
+                                    SyntaxFactory.IdentifierName($"{node.SourceTable.Alias}Rows.Rows"),
+                                    SyntaxFactory.Block(
+                                        GenerateCancellationExpression(),
+                                        (StatementSyntax) ifStatement,
+                                        _emptyBlock,
+                                        SyntaxFactory.IfStatement(
+                                            (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                                SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                            SyntaxFactory.Block(
+                                                SyntaxFactory.ExpressionStatement(
+                                                    SyntaxFactory.AssignmentExpression(
+                                                        SyntaxKind.SimpleAssignmentExpression,
+                                                        SyntaxFactory.IdentifierName("hasAnyRowMatched"),
+                                                        (LiteralExpressionSyntax) Generator
+                                                            .TrueLiteralExpression())))))),
                                 SyntaxFactory.IfStatement(
-                                    (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                    (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                        SyntaxFactory.IdentifierName("hasAnyRowMatched")),
                                     SyntaxFactory.Block(
                                         SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
                                         SyntaxFactory.ExpressionStatement(invocation))))));
@@ -1324,13 +1364,14 @@ namespace Musoq.Evaluator.Visitors
                                 SyntaxFactory.CastExpression(
                                     SyntaxFactory.IdentifierName(
                                         EvaluationHelper.GetCastableType(column.ColumnType)),
-                                    (LiteralExpressionSyntax)Generator.NullLiteralExpression()));
+                                    (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
 
                             j += 1;
                         }
                     }
 
-                    foreach (var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[fullTransitionTable.CompoundTables.Length - 1]))
+                    foreach (var column in fullTransitionTable.GetColumns(
+                                 fullTransitionTable.CompoundTables[fullTransitionTable.CompoundTables.Length - 1]))
                     {
                         expressions.Add(
                             SyntaxFactory.ElementAccessExpression(
@@ -1338,15 +1379,16 @@ namespace Musoq.Evaluator.Visitors
                                 SyntaxFactory.BracketedArgumentList(
                                     SyntaxFactory.SingletonSeparatedList(
                                         SyntaxFactory.Argument(
-                                            (LiteralExpressionSyntax)Generator.LiteralExpression(fieldNames.Names[j++]))))));
+                                            (LiteralExpressionSyntax) Generator.LiteralExpression(
+                                                fieldNames.Names[j++]))))));
                     }
 
                     arrayType = SyntaxFactory.ArrayType(
-                                        SyntaxFactory.IdentifierName("object"),
-                                        new SyntaxList<ArrayRankSpecifierSyntax>(
-                                            SyntaxFactory.ArrayRankSpecifier(
-                                            SyntaxFactory.SingletonSeparatedList(
-                                                (ExpressionSyntax)SyntaxFactory.OmittedArraySizeExpression()))));
+                        SyntaxFactory.IdentifierName("object"),
+                        new SyntaxList<ArrayRankSpecifierSyntax>(
+                            SyntaxFactory.ArrayRankSpecifier(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    (ExpressionSyntax) SyntaxFactory.OmittedArraySizeExpression()))));
 
                     rewriteSelect =
                         SyntaxFactory.VariableDeclaration(
@@ -1363,7 +1405,6 @@ namespace Musoq.Evaluator.Visitors
                                                 SyntaxFactory.SeparatedList(expressions)))))));
 
 
-
                     invocation = SyntaxHelper.CreateMethodInvocation(
                         _scope[MetaAttributes.SelectIntoVariableName],
                         nameof(Table.Add),
@@ -1371,7 +1412,8 @@ namespace Musoq.Evaluator.Visitors
                         {
                             SyntaxFactory.Argument(
                                 SyntaxFactory.ObjectCreationExpression(
-                                    SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxHelper.WhiteSpace),
+                                    SyntaxFactory.Token(SyntaxKind.NewKeyword)
+                                        .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                                     SyntaxFactory.ParseTypeName(nameof(ObjectsRow)),
                                     SyntaxFactory.ArgumentList(
                                         SyntaxFactory.SeparatedList(
@@ -1379,16 +1421,18 @@ namespace Musoq.Evaluator.Visitors
                                             {
                                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("select")),
                                                 SyntaxFactory.Argument(
-                                                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                                                    SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
                                                 SyntaxFactory.Argument(
                                                     SyntaxFactory.MemberAccessExpression(
                                                         SyntaxKind.SimpleMemberAccessExpression,
                                                         SyntaxFactory.IdentifierName($"{node.SourceTable.Alias}Row"),
-                                                        SyntaxFactory.IdentifierName($"{nameof(IObjectResolver.Contexts)}")))
+                                                        SyntaxFactory.IdentifierName(
+                                                            $"{nameof(IObjectResolver.Contexts)}")))
                                             })
                                     ),
                                     SyntaxFactory.InitializerExpression(SyntaxKind.ComplexElementInitializerExpression))
-                            )});    
+                            )
+                        });
 
                     computingBlock = computingBlock.AddStatements(
                         SyntaxFactory.ForEachStatement(
@@ -1397,26 +1441,30 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.IdentifierName($"{node.SourceTable.Alias}Rows.Rows"),
                             SyntaxFactory.Block(
                                 SyntaxFactory.LocalDeclarationStatement(
-                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched", SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))),
+                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched",
+                                        SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))),
                                 SyntaxFactory.ForEachStatement(
-                                        SyntaxFactory.IdentifierName("var"),
-                                        SyntaxFactory.Identifier($"{node.InMemoryTableAlias}Row"),
-                                        SyntaxFactory.IdentifierName(
-                                            $"{nameof(EvaluationHelper)}.{nameof(EvaluationHelper.ConvertTableToSource)}({node.InMemoryTableAlias}TransitionTable).{nameof(RowSource.Rows)}"),
-                                        SyntaxFactory.Block(
-                                            GenerateCancellationExpression(),
-                                            (StatementSyntax)ifStatement,
-                                            _emptyBlock,
-                                            SyntaxFactory.IfStatement(
-                                                (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                                SyntaxFactory.Block(
-                                                    SyntaxFactory.ExpressionStatement(
-                                                        SyntaxFactory.AssignmentExpression(
-                                                            SyntaxKind.SimpleAssignmentExpression,
-                                                            SyntaxFactory.IdentifierName("hasAnyRowMatched"),
-                                                            (LiteralExpressionSyntax)Generator.TrueLiteralExpression())))))),
+                                    SyntaxFactory.IdentifierName("var"),
+                                    SyntaxFactory.Identifier($"{node.InMemoryTableAlias}Row"),
+                                    SyntaxFactory.IdentifierName(
+                                        $"{nameof(EvaluationHelper)}.{nameof(EvaluationHelper.ConvertTableToSource)}({node.InMemoryTableAlias}TransitionTable).{nameof(RowSource.Rows)}"),
+                                    SyntaxFactory.Block(
+                                        GenerateCancellationExpression(),
+                                        (StatementSyntax) ifStatement,
+                                        _emptyBlock,
+                                        SyntaxFactory.IfStatement(
+                                            (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                                SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                            SyntaxFactory.Block(
+                                                SyntaxFactory.ExpressionStatement(
+                                                    SyntaxFactory.AssignmentExpression(
+                                                        SyntaxKind.SimpleAssignmentExpression,
+                                                        SyntaxFactory.IdentifierName("hasAnyRowMatched"),
+                                                        (LiteralExpressionSyntax) Generator
+                                                            .TrueLiteralExpression())))))),
                                 SyntaxFactory.IfStatement(
-                                    (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                    (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                        SyntaxFactory.IdentifierName("hasAnyRowMatched")),
                                     SyntaxFactory.Block(
                                         SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
                                         SyntaxFactory.ExpressionStatement(invocation))))));
@@ -1441,13 +1489,13 @@ namespace Musoq.Evaluator.Visitors
                         SyntaxFactory.ArgumentList(
                             SyntaxFactory.SeparatedList(new[]
                             {
-                                    SyntaxFactory.Argument(
-                                        SyntaxFactory.LiteralExpression(
-                                            SyntaxKind.StringLiteralExpression,
-                                            SyntaxFactory.Literal(column.ColumnName))),
-                                    SyntaxHelper.TypeLiteralArgument(
-                                        EvaluationHelper.GetCastableType(column.ColumnType)),
-                                    SyntaxHelper.IntLiteralArgument(column.ColumnIndex)
+                                SyntaxFactory.Argument(
+                                    SyntaxFactory.LiteralExpression(
+                                        SyntaxKind.StringLiteralExpression,
+                                        SyntaxFactory.Literal(column.ColumnName))),
+                                SyntaxHelper.TypeLiteralArgument(
+                                    EvaluationHelper.GetCastableType(column.ColumnType)),
+                                SyntaxHelper.IntLiteralArgument(column.ColumnIndex)
                             }))));
             }
 
@@ -1486,23 +1534,27 @@ namespace Musoq.Evaluator.Visitors
                         SyntaxHelper.StringLiteralArgument(node.Method),
                         SyntaxFactory.Argument(
                             SyntaxFactory.ObjectCreationExpression(
-                                SyntaxFactory.IdentifierName(nameof(RuntimeContext)))
+                                    SyntaxFactory.IdentifierName(nameof(RuntimeContext)))
                                 .WithArgumentList(
                                     SyntaxFactory.ArgumentList(
                                         SyntaxFactory.SeparatedList(
-                                            new []{
+                                            new[]
+                                            {
                                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("token")),
-                                                SyntaxFactory.Argument(SyntaxFactory.IdentifierName(tableInfoVariableName)),
+                                                SyntaxFactory.Argument(
+                                                    SyntaxFactory.IdentifierName(tableInfoVariableName)),
                                                 SyntaxFactory.Argument(
                                                     SyntaxFactory.ElementAccessExpression(
-                                                            SyntaxFactory.IdentifierName("positionalEnvironmentVariables"))
+                                                            SyntaxFactory.IdentifierName(
+                                                                "positionalEnvironmentVariables"))
                                                         .WithArgumentList(
                                                             SyntaxFactory.BracketedArgumentList(
                                                                 SyntaxFactory.SingletonSeparatedList(
                                                                     SyntaxFactory.Argument(
                                                                         SyntaxFactory.LiteralExpression(
                                                                             SyntaxKind.NumericLiteralExpression,
-                                                                            SyntaxFactory.Literal(_schemaFromIndex++))))))
+                                                                            SyntaxFactory.Literal(
+                                                                                _schemaFromIndex++))))))
                                                 ),
                                                 SyntaxFactory.Argument(
                                                     SyntaxFactory.ElementAccessExpression(
@@ -1539,21 +1591,21 @@ namespace Musoq.Evaluator.Visitors
             switch (node.JoinType)
             {
                 case JoinType.Inner:
-                    computingBlock = 
+                    computingBlock =
                         computingBlock.AddStatements(
                             SyntaxFactory.ForEachStatement(SyntaxFactory.IdentifierName("var"),
-                            SyntaxFactory.Identifier($"{node.First.Alias}Row"),
-                            SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
-                            SyntaxFactory.Block(
-                                SyntaxFactory.SingletonList<StatementSyntax>(
-                                    SyntaxFactory.ForEachStatement(
-                                        SyntaxFactory.IdentifierName("var"), 
-                                        SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
-                                        SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
-                                        SyntaxFactory.Block(
-                                            GenerateCancellationExpression(),
-                                            (StatementSyntax)ifStatement,
-                                            _emptyBlock))))));
+                                SyntaxFactory.Identifier($"{node.First.Alias}Row"),
+                                SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
+                                SyntaxFactory.Block(
+                                    SyntaxFactory.SingletonList<StatementSyntax>(
+                                        SyntaxFactory.ForEachStatement(
+                                            SyntaxFactory.IdentifierName("var"),
+                                            SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
+                                            SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
+                                            SyntaxFactory.Block(
+                                                GenerateCancellationExpression(),
+                                                (StatementSyntax) ifStatement,
+                                                _emptyBlock))))));
                     break;
                 case JoinType.OuterLeft:
 
@@ -1564,11 +1616,12 @@ namespace Musoq.Evaluator.Visitors
                     {
                         expressions.Add(
                             SyntaxFactory.ElementAccessExpression(
-                                SyntaxFactory.IdentifierName($"{node.First.Alias}Row"), 
+                                SyntaxFactory.IdentifierName($"{node.First.Alias}Row"),
                                 SyntaxFactory.BracketedArgumentList(
                                     SyntaxFactory.SingletonSeparatedList(
                                         SyntaxFactory.Argument(
-                                            (LiteralExpressionSyntax)Generator.LiteralExpression(column.ColumnName))))));
+                                            (LiteralExpressionSyntax) Generator.LiteralExpression(
+                                                column.ColumnName))))));
                     }
 
                     foreach (var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[1]))
@@ -1577,17 +1630,17 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.CastExpression(
                                 SyntaxFactory.IdentifierName(
                                     EvaluationHelper.GetCastableType(column.ColumnType)),
-                                (LiteralExpressionSyntax)Generator.NullLiteralExpression()));
+                                (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                     }
 
                     var arrayType = SyntaxFactory.ArrayType(
-                                        SyntaxFactory.IdentifierName("object"),
-                                        new SyntaxList<ArrayRankSpecifierSyntax>(
-                                            SyntaxFactory.ArrayRankSpecifier(
-                                            SyntaxFactory.SingletonSeparatedList(
-                                                (ExpressionSyntax)SyntaxFactory.OmittedArraySizeExpression()))));
+                        SyntaxFactory.IdentifierName("object"),
+                        new SyntaxList<ArrayRankSpecifierSyntax>(
+                            SyntaxFactory.ArrayRankSpecifier(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    (ExpressionSyntax) SyntaxFactory.OmittedArraySizeExpression()))));
 
-                    var rewriteSelect = 
+                    var rewriteSelect =
                         SyntaxFactory.VariableDeclaration(
                             SyntaxFactory.IdentifierName("var"),
                             SyntaxFactory.SingletonSeparatedList(
@@ -1602,7 +1655,6 @@ namespace Musoq.Evaluator.Visitors
                                                 SyntaxFactory.SeparatedList(expressions)))))));
 
 
-
                     var invocation = SyntaxHelper.CreateMethodInvocation(
                         _scope[MetaAttributes.SelectIntoVariableName],
                         nameof(Table.Add),
@@ -1610,7 +1662,8 @@ namespace Musoq.Evaluator.Visitors
                         {
                             SyntaxFactory.Argument(
                                 SyntaxFactory.ObjectCreationExpression(
-                                    SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxHelper.WhiteSpace),
+                                    SyntaxFactory.Token(SyntaxKind.NewKeyword)
+                                        .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                                     SyntaxFactory.ParseTypeName(nameof(ObjectsRow)),
                                     SyntaxFactory.ArgumentList(
                                         SyntaxFactory.SeparatedList(
@@ -1621,43 +1674,49 @@ namespace Musoq.Evaluator.Visitors
                                                     SyntaxFactory.MemberAccessExpression(
                                                         SyntaxKind.SimpleMemberAccessExpression,
                                                         SyntaxFactory.IdentifierName($"{node.First.Alias}Row"),
-                                                        SyntaxFactory.IdentifierName($"{nameof(IObjectResolver.Contexts)}"))),
+                                                        SyntaxFactory.IdentifierName(
+                                                            $"{nameof(IObjectResolver.Contexts)}"))),
                                                 SyntaxFactory.Argument(
-                                                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
+                                                    SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
                                             })
                                     ),
                                     SyntaxFactory.InitializerExpression(SyntaxKind.ComplexElementInitializerExpression))
-                            )});
+                            )
+                        });
 
                     computingBlock =
                         computingBlock.AddStatements(
                             SyntaxFactory.ForEachStatement(SyntaxFactory.IdentifierName("var"),
-                            SyntaxFactory.Identifier($"{node.First.Alias}Row"),
-                            SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
-                            SyntaxFactory.Block(
-                                SyntaxFactory.LocalDeclarationStatement(
-                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched", (LiteralExpressionSyntax)Generator.FalseLiteralExpression())),
-                                SyntaxFactory.ForEachStatement(
-                                    SyntaxFactory.IdentifierName("var"),
-                                    SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
-                                    SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
-                                    SyntaxFactory.Block(
-                                        GenerateCancellationExpression(),
-                                        (StatementSyntax)ifStatement,
-                                        _emptyBlock,
-                                        SyntaxFactory.IfStatement(
-                                            (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                            SyntaxFactory.Block(
-                                                SyntaxFactory.ExpressionStatement(
-                                                    SyntaxFactory.AssignmentExpression(
-                                                        SyntaxKind.SimpleAssignmentExpression,
-                                                        SyntaxFactory.IdentifierName("hasAnyRowMatched"),
-                                                        (LiteralExpressionSyntax)Generator.TrueLiteralExpression())))))),
-                                SyntaxFactory.IfStatement(
-                                    (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                    SyntaxFactory.Block(
-                                        SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
-                                        SyntaxFactory.ExpressionStatement(invocation))))));
+                                SyntaxFactory.Identifier($"{node.First.Alias}Row"),
+                                SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
+                                SyntaxFactory.Block(
+                                    SyntaxFactory.LocalDeclarationStatement(
+                                        SyntaxHelper.CreateAssignment("hasAnyRowMatched",
+                                            (LiteralExpressionSyntax) Generator.FalseLiteralExpression())),
+                                    SyntaxFactory.ForEachStatement(
+                                        SyntaxFactory.IdentifierName("var"),
+                                        SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
+                                        SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
+                                        SyntaxFactory.Block(
+                                            GenerateCancellationExpression(),
+                                            (StatementSyntax) ifStatement,
+                                            _emptyBlock,
+                                            SyntaxFactory.IfStatement(
+                                                (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                                    SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                                SyntaxFactory.Block(
+                                                    SyntaxFactory.ExpressionStatement(
+                                                        SyntaxFactory.AssignmentExpression(
+                                                            SyntaxKind.SimpleAssignmentExpression,
+                                                            SyntaxFactory.IdentifierName("hasAnyRowMatched"),
+                                                            (LiteralExpressionSyntax) Generator
+                                                                .TrueLiteralExpression())))))),
+                                    SyntaxFactory.IfStatement(
+                                        (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                            SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                        SyntaxFactory.Block(
+                                            SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
+                                            SyntaxFactory.ExpressionStatement(invocation))))));
                     break;
                 case JoinType.OuterRight:
 
@@ -1670,7 +1729,7 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.CastExpression(
                                 SyntaxFactory.IdentifierName(
                                     EvaluationHelper.GetCastableType(column.ColumnType)),
-                                (LiteralExpressionSyntax)Generator.NullLiteralExpression()));
+                                (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                     }
 
                     foreach (var column in fullTransitionTable.GetColumns(fullTransitionTable.CompoundTables[1]))
@@ -1681,15 +1740,16 @@ namespace Musoq.Evaluator.Visitors
                                 SyntaxFactory.BracketedArgumentList(
                                     SyntaxFactory.SingletonSeparatedList(
                                         SyntaxFactory.Argument(
-                                            (LiteralExpressionSyntax)Generator.LiteralExpression(column.ColumnName))))));
+                                            (LiteralExpressionSyntax) Generator.LiteralExpression(
+                                                column.ColumnName))))));
                     }
 
                     arrayType = SyntaxFactory.ArrayType(
-                                        SyntaxFactory.IdentifierName("object"),
-                                        new SyntaxList<ArrayRankSpecifierSyntax>(
-                                            SyntaxFactory.ArrayRankSpecifier(
-                                            SyntaxFactory.SingletonSeparatedList(
-                                                (ExpressionSyntax)SyntaxFactory.OmittedArraySizeExpression()))));
+                        SyntaxFactory.IdentifierName("object"),
+                        new SyntaxList<ArrayRankSpecifierSyntax>(
+                            SyntaxFactory.ArrayRankSpecifier(
+                                SyntaxFactory.SingletonSeparatedList(
+                                    (ExpressionSyntax) SyntaxFactory.OmittedArraySizeExpression()))));
 
                     rewriteSelect =
                         SyntaxFactory.VariableDeclaration(
@@ -1713,7 +1773,8 @@ namespace Musoq.Evaluator.Visitors
                         {
                             SyntaxFactory.Argument(
                                 SyntaxFactory.ObjectCreationExpression(
-                                    SyntaxFactory.Token(SyntaxKind.NewKeyword).WithTrailingTrivia(SyntaxHelper.WhiteSpace),
+                                    SyntaxFactory.Token(SyntaxKind.NewKeyword)
+                                        .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                                     SyntaxFactory.ParseTypeName(nameof(ObjectsRow)),
                                     SyntaxFactory.ArgumentList(
                                         SyntaxFactory.SeparatedList(
@@ -1721,46 +1782,52 @@ namespace Musoq.Evaluator.Visitors
                                             {
                                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("select")),
                                                 SyntaxFactory.Argument(
-                                                        SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                                                    SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
                                                 SyntaxFactory.Argument(
                                                     SyntaxFactory.MemberAccessExpression(
                                                         SyntaxKind.SimpleMemberAccessExpression,
                                                         SyntaxFactory.IdentifierName($"{node.Second.Alias}Row"),
-                                                        SyntaxFactory.IdentifierName($"{nameof(IObjectResolver.Contexts)}")))
+                                                        SyntaxFactory.IdentifierName(
+                                                            $"{nameof(IObjectResolver.Contexts)}")))
                                             })
                                     ),
                                     SyntaxFactory.InitializerExpression(SyntaxKind.ComplexElementInitializerExpression))
-                            )});
+                            )
+                        });
 
                     computingBlock =
                         computingBlock.AddStatements(
                             SyntaxFactory.ForEachStatement(SyntaxFactory.IdentifierName("var"),
-                            SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
-                            SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
-                            SyntaxFactory.Block(
-                                SyntaxFactory.LocalDeclarationStatement(
-                                    SyntaxHelper.CreateAssignment("hasAnyRowMatched", (LiteralExpressionSyntax)Generator.FalseLiteralExpression())),
-                                SyntaxFactory.ForEachStatement(
-                                    SyntaxFactory.IdentifierName("var"),
-                                    SyntaxFactory.Identifier($"{node.First.Alias}Row"),
-                                    SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
-                                    SyntaxFactory.Block(
-                                        GenerateCancellationExpression(),
-                                        (StatementSyntax)ifStatement,
-                                        _emptyBlock,
-                                        SyntaxFactory.IfStatement(
-                                            (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                            SyntaxFactory.Block(
-                                                SyntaxFactory.ExpressionStatement(
-                                                    SyntaxFactory.AssignmentExpression(
-                                                        SyntaxKind.SimpleAssignmentExpression,
-                                                        SyntaxFactory.IdentifierName("hasAnyRowMatched"),
-                                                        (LiteralExpressionSyntax)Generator.TrueLiteralExpression())))))),
-                                SyntaxFactory.IfStatement(
-                                    (PrefixUnaryExpressionSyntax)Generator.LogicalNotExpression(SyntaxFactory.IdentifierName("hasAnyRowMatched")),
-                                    SyntaxFactory.Block(
-                                        SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
-                                        SyntaxFactory.ExpressionStatement(invocation))))));
+                                SyntaxFactory.Identifier($"{node.Second.Alias}Row"),
+                                SyntaxFactory.IdentifierName($"{node.Second.Alias}Rows.Rows"),
+                                SyntaxFactory.Block(
+                                    SyntaxFactory.LocalDeclarationStatement(
+                                        SyntaxHelper.CreateAssignment("hasAnyRowMatched",
+                                            (LiteralExpressionSyntax) Generator.FalseLiteralExpression())),
+                                    SyntaxFactory.ForEachStatement(
+                                        SyntaxFactory.IdentifierName("var"),
+                                        SyntaxFactory.Identifier($"{node.First.Alias}Row"),
+                                        SyntaxFactory.IdentifierName($"{node.First.Alias}Rows.Rows"),
+                                        SyntaxFactory.Block(
+                                            GenerateCancellationExpression(),
+                                            (StatementSyntax) ifStatement,
+                                            _emptyBlock,
+                                            SyntaxFactory.IfStatement(
+                                                (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                                    SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                                SyntaxFactory.Block(
+                                                    SyntaxFactory.ExpressionStatement(
+                                                        SyntaxFactory.AssignmentExpression(
+                                                            SyntaxKind.SimpleAssignmentExpression,
+                                                            SyntaxFactory.IdentifierName("hasAnyRowMatched"),
+                                                            (LiteralExpressionSyntax) Generator
+                                                                .TrueLiteralExpression())))))),
+                                    SyntaxFactory.IfStatement(
+                                        (PrefixUnaryExpressionSyntax) Generator.LogicalNotExpression(
+                                            SyntaxFactory.IdentifierName("hasAnyRowMatched")),
+                                        SyntaxFactory.Block(
+                                            SyntaxFactory.LocalDeclarationStatement(rewriteSelect),
+                                            SyntaxFactory.ExpressionStatement(invocation))))));
                     break;
             }
 
@@ -1826,8 +1893,8 @@ namespace Musoq.Evaluator.Visitors
                                 {
                                     SyntaxFactory.Argument(
                                         SyntaxFactory.LiteralExpression(
-                                            SyntaxKind.StringLiteralExpression, 
-                                            SyntaxFactory.Literal( $"@\"{field.FieldName}\"", field.FieldName))),
+                                            SyntaxKind.StringLiteralExpression,
+                                            SyntaxFactory.Literal($"@\"{field.FieldName}\"", field.FieldName))),
                                     SyntaxHelper.TypeLiteralArgument(
                                         EvaluationHelper.GetCastableType(type)),
                                     SyntaxHelper.IntLiteralArgument(field.FieldOrder)
@@ -1860,6 +1927,7 @@ namespace Musoq.Evaluator.Visitors
                         SyntaxFactory.ArgumentList()));
                 Statements.Add(SyntaxFactory.LocalDeclarationStatement(createObject));
             }
+
             NullSuspiciousNodes.Clear();
         }
 
@@ -1944,7 +2012,7 @@ namespace Musoq.Evaluator.Visitors
 
                 block = block.AddStatements(GenerateCancellationExpression());
 
-                if(where != null)
+                if (where != null)
                     block = block.AddStatements(where);
 
                 block = block.AddStatements(SyntaxFactory.LocalDeclarationStatement(_groupKeys));
@@ -2006,11 +2074,11 @@ namespace Musoq.Evaluator.Visitors
         {
             return SyntaxFactory.ExpressionStatement(
                 SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("token"),
-                    SyntaxFactory.IdentifierName(
-                        nameof(CancellationToken.ThrowIfCancellationRequested)))));
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("token"),
+                        SyntaxFactory.IdentifierName(
+                            nameof(CancellationToken.ThrowIfCancellationRequested)))));
         }
 
         public void Visit(RootNode node)
@@ -2024,16 +2092,18 @@ namespace Musoq.Evaluator.Visitors
                 SyntaxFactory.Identifier(nameof(IRunnable.Run)),
                 null,
                 SyntaxFactory.ParameterList(
-                    SyntaxFactory.SeparatedList(new []
+                    SyntaxFactory.SeparatedList(new[]
                     {
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxTokenList.Create(new SyntaxToken()),
-                            SyntaxFactory.IdentifierName(nameof(CancellationToken)).WithTrailingTrivia(SyntaxHelper.WhiteSpace),
+                            SyntaxFactory.IdentifierName(nameof(CancellationToken))
+                                .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("token"), null)
                     })),
                 new SyntaxList<TypeParameterConstraintClauseSyntax>(),
-                SyntaxFactory.Block(SyntaxFactory.ParseStatement($"return {_methodNames.Pop()}(Provider, PositionalEnvironmentVariables, QueriesInformation, token);")),
+                SyntaxFactory.Block(SyntaxFactory.ParseStatement(
+                    $"return {_methodNames.Pop()}(Provider, PositionalEnvironmentVariables, QueriesInformation, token);")),
                 null);
 
             var providerParam = SyntaxFactory.PropertyDeclaration(
@@ -2122,7 +2192,12 @@ namespace Musoq.Evaluator.Visitors
                                                                                 SyntaxFactory.IdentifierName(
                                                                                     "ISchemaColumn")))))
                                                         .WithIdentifier(
-                                                            SyntaxFactory.Identifier("UsedColumns"))
+                                                            SyntaxFactory.Identifier("UsedColumns")),
+                                                    SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                    SyntaxFactory.TupleElement(
+                                                            SyntaxFactory.IdentifierName("WhereNode"))
+                                                        .WithIdentifier(
+                                                            SyntaxFactory.Identifier("WhereNode"))
                                                 }))
                                     }))),
                     SyntaxFactory.Identifier("QueriesInformation"))
@@ -2230,7 +2305,7 @@ namespace Musoq.Evaluator.Visitors
                                 SyntaxFactory.Argument(
                                     SyntaxFactory.IdentifierName("token"))
                             }
-                            )));
+                        )));
 
             var bInvocation = SyntaxFactory
                 .InvocationExpression(SyntaxFactory.IdentifierName(b))
@@ -2446,7 +2521,7 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.IdentifierName(nameof(ISchemaProvider))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("provider"), null),
-                        
+
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxTokenList.Create(
@@ -2456,7 +2531,8 @@ namespace Musoq.Evaluator.Visitors
                                 .WithTypeArgumentList(
                                     SyntaxFactory.TypeArgumentList(
                                         SyntaxFactory.SeparatedList<TypeSyntax>(
-                                            new SyntaxNodeOrToken[]{
+                                            new SyntaxNodeOrToken[]
+                                            {
                                                 SyntaxFactory.PredefinedType(
                                                     SyntaxFactory.Token(SyntaxKind.UIntKeyword)),
                                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
@@ -2465,12 +2541,15 @@ namespace Musoq.Evaluator.Visitors
                                                     .WithTypeArgumentList(
                                                         SyntaxFactory.TypeArgumentList(
                                                             SyntaxFactory.SeparatedList<TypeSyntax>(
-                                                                new SyntaxNodeOrToken[]{
+                                                                new SyntaxNodeOrToken[]
+                                                                {
                                                                     SyntaxFactory.PredefinedType(
                                                                         SyntaxFactory.Token(SyntaxKind.StringKeyword)),
                                                                     SyntaxFactory.Token(SyntaxKind.CommaToken),
                                                                     SyntaxFactory.PredefinedType(
-                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))})))})))
+                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))
+                                                                })))
+                                            })))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("positionalEnvironmentVariables"), null),
 
@@ -2509,7 +2588,12 @@ namespace Musoq.Evaluator.Visitors
                                                                                                 .IdentifierName(
                                                                                                     "ISchemaColumn")))))
                                                                     .WithIdentifier(
-                                                                        SyntaxFactory.Identifier("UsedColumns"))
+                                                                        SyntaxFactory.Identifier("UsedColumns")),
+                                                                SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                SyntaxFactory.TupleElement(
+                                                                        SyntaxFactory.IdentifierName("WhereNode"))
+                                                                    .WithIdentifier(
+                                                                        SyntaxFactory.Identifier("WhereNode"))
                                                             }))
                                                 })))),
 
@@ -2576,7 +2660,7 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxFactory.IdentifierName(nameof(ISchemaProvider))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("provider"), null),
-                        
+
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxTokenList.Create(
@@ -2586,7 +2670,8 @@ namespace Musoq.Evaluator.Visitors
                                 .WithTypeArgumentList(
                                     SyntaxFactory.TypeArgumentList(
                                         SyntaxFactory.SeparatedList<TypeSyntax>(
-                                            new SyntaxNodeOrToken[]{
+                                            new SyntaxNodeOrToken[]
+                                            {
                                                 SyntaxFactory.PredefinedType(
                                                     SyntaxFactory.Token(SyntaxKind.UIntKeyword)),
                                                 SyntaxFactory.Token(SyntaxKind.CommaToken),
@@ -2595,12 +2680,15 @@ namespace Musoq.Evaluator.Visitors
                                                     .WithTypeArgumentList(
                                                         SyntaxFactory.TypeArgumentList(
                                                             SyntaxFactory.SeparatedList<TypeSyntax>(
-                                                                new SyntaxNodeOrToken[]{
+                                                                new SyntaxNodeOrToken[]
+                                                                {
                                                                     SyntaxFactory.PredefinedType(
                                                                         SyntaxFactory.Token(SyntaxKind.StringKeyword)),
                                                                     SyntaxFactory.Token(SyntaxKind.CommaToken),
                                                                     SyntaxFactory.PredefinedType(
-                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))})))})))
+                                                                        SyntaxFactory.Token(SyntaxKind.StringKeyword))
+                                                                })))
+                                            })))
                                 .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                             SyntaxFactory.Identifier("positionalEnvironmentVariables"), null),
 
@@ -2639,10 +2727,15 @@ namespace Musoq.Evaluator.Visitors
                                                                                                 .IdentifierName(
                                                                                                     "ISchemaColumn")))))
                                                                     .WithIdentifier(
-                                                                        SyntaxFactory.Identifier("UsedColumns"))
+                                                                        SyntaxFactory.Identifier("UsedColumns")),
+                                                                SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                SyntaxFactory.TupleElement(
+                                                                        SyntaxFactory.IdentifierName("WhereNode"))
+                                                                    .WithIdentifier(
+                                                                        SyntaxFactory.Identifier("WhereNode"))
                                                             }))
                                                 })))),
-                        
+
                         SyntaxFactory.Parameter(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxTokenList.Create(
@@ -2673,7 +2766,7 @@ namespace Musoq.Evaluator.Visitors
                 SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(_methodNames.Peek())).WithArgumentList(
                     SyntaxFactory.ArgumentList(
                         SyntaxFactory.SeparatedList(
-                            new []
+                            new[]
                             {
                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("provider")),
                                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName("positionalEnvironmentVariables")),
@@ -2730,7 +2823,7 @@ namespace Musoq.Evaluator.Visitors
             foreach (var type in types)
             {
                 if (_loadedAssemblies.Contains(type.Assembly.Location)) continue;
-                
+
                 _loadedAssemblies.Add(type.Assembly.Location);
                 Compilation =
                     Compilation.AddReferences(MetadataReference.CreateFromFile(type.Assembly.Location));
@@ -2762,9 +2855,9 @@ namespace Musoq.Evaluator.Visitors
             return SyntaxFactory.Block(
                 SyntaxFactory.ForEachStatement(
                     SyntaxFactory.IdentifierName("var"),
-                    SyntaxFactory.Identifier(variableName), 
+                    SyntaxFactory.Identifier(variableName),
                     SyntaxFactory.IdentifierName(tableVariable),
-                foreachInstructions).NormalizeWhitespace());
+                    foreachInstructions).NormalizeWhitespace());
         }
 
         private StatementSyntax AddGroupStatement(string scoreTable)
@@ -2908,7 +3001,7 @@ namespace Musoq.Evaluator.Visitors
                 .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword)))
                 .WithParameterList(SyntaxFactory.ParameterList(
                     SyntaxFactory.SeparatedList(
-                        new []
+                        new[]
                         {
                             SyntaxFactory.Parameter(SyntaxFactory.Identifier("provider"))
                                 .WithType(SyntaxFactory.IdentifierName(nameof(ISchemaProvider))),
@@ -2945,34 +3038,49 @@ namespace Musoq.Evaluator.Visitors
                                     .WithTrailingTrivia(SyntaxHelper.WhiteSpace),
                                 SyntaxFactory.Identifier("positionalEnvironmentVariables"), null),
                             SyntaxFactory.Parameter(
-                                SyntaxFactory.Identifier("queriesInformation"))
-                            .WithType(
-                                SyntaxFactory.GenericName(
-                                    SyntaxFactory.Identifier("IReadOnlyDictionary"))
-                                .WithTypeArgumentList(
-                                    SyntaxFactory.TypeArgumentList(
-                                        SyntaxFactory.SeparatedList<TypeSyntax>(
-                                            new SyntaxNodeOrToken[]{
-                                                SyntaxFactory.PredefinedType(
-                                                    SyntaxFactory.Token(SyntaxKind.StringKeyword)),
-                                                SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                                SyntaxFactory.TupleType(
-                                                    SyntaxFactory.SeparatedList<TupleElementSyntax>(
-                                                        new SyntaxNodeOrToken[]{
-                                                            SyntaxFactory.TupleElement(
-                                                                SyntaxFactory.IdentifierName("SchemaFromNode"))
-                                                            .WithIdentifier(
-                                                                SyntaxFactory.Identifier("FromNode")),
-                                                            SyntaxFactory.Token(SyntaxKind.CommaToken),
-                                                            SyntaxFactory.TupleElement(
-                                                                SyntaxFactory.GenericName(
-                                                                    SyntaxFactory.Identifier("IReadOnlyCollection"))
-                                                                .WithTypeArgumentList(
-                                                                    SyntaxFactory.TypeArgumentList(
-                                                                        SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
-                                                                            SyntaxFactory.IdentifierName("ISchemaColumn")))))
-                                                            .WithIdentifier(
-                                                                SyntaxFactory.Identifier("UsedColumns"))}))})))),
+                                    SyntaxFactory.Identifier("queriesInformation"))
+                                .WithType(
+                                    SyntaxFactory.GenericName(
+                                            SyntaxFactory.Identifier("IReadOnlyDictionary"))
+                                        .WithTypeArgumentList(
+                                            SyntaxFactory.TypeArgumentList(
+                                                SyntaxFactory.SeparatedList<TypeSyntax>(
+                                                    new SyntaxNodeOrToken[]
+                                                    {
+                                                        SyntaxFactory.PredefinedType(
+                                                            SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                                                        SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                        SyntaxFactory.TupleType(
+                                                            SyntaxFactory.SeparatedList<TupleElementSyntax>(
+                                                                new SyntaxNodeOrToken[]
+                                                                {
+                                                                    SyntaxFactory.TupleElement(
+                                                                            SyntaxFactory.IdentifierName(
+                                                                                "SchemaFromNode"))
+                                                                        .WithIdentifier(
+                                                                            SyntaxFactory.Identifier("FromNode")),
+                                                                    SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                    SyntaxFactory.TupleElement(
+                                                                            SyntaxFactory.GenericName(
+                                                                                    SyntaxFactory.Identifier(
+                                                                                        "IReadOnlyCollection"))
+                                                                                .WithTypeArgumentList(
+                                                                                    SyntaxFactory.TypeArgumentList(
+                                                                                        SyntaxFactory
+                                                                                            .SingletonSeparatedList<
+                                                                                                TypeSyntax>(
+                                                                                                SyntaxFactory
+                                                                                                    .IdentifierName(
+                                                                                                        "ISchemaColumn")))))
+                                                                        .WithIdentifier(
+                                                                            SyntaxFactory.Identifier("UsedColumns")),
+                                                                    SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                                                    SyntaxFactory.TupleElement(
+                                                                            SyntaxFactory.IdentifierName("WhereNode"))
+                                                                        .WithIdentifier(
+                                                                            SyntaxFactory.Identifier("WhereNode"))
+                                                                }))
+                                                    })))),
                             SyntaxFactory.Parameter(SyntaxFactory.Identifier("token"))
                                 .WithType(SyntaxFactory.IdentifierName(nameof(CancellationToken)))
                         }))).WithBody(
@@ -3067,14 +3175,14 @@ namespace Musoq.Evaluator.Visitors
                             SyntaxKind.LogicalAndExpression,
                             SyntaxFactory.BinaryExpression(
                                 SyntaxKind.NotEqualsExpression,
-                                (ExpressionSyntax)NullSuspiciousNodes.Pop(),
+                                (ExpressionSyntax) NullSuspiciousNodes.Pop(),
                                 SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
                             SyntaxFactory.BinaryExpression(
                                 SyntaxKind.NotEqualsExpression,
-                                (ExpressionSyntax)NullSuspiciousNodes.Pop(),
+                                (ExpressionSyntax) NullSuspiciousNodes.Pop(),
                                 SyntaxFactory.LiteralExpression(
                                     SyntaxKind.NullLiteralExpression))),
-                        (BinaryExpressionSyntax)rawNode));
+                        (BinaryExpressionSyntax) rawNode));
             }
             else if (NullSuspiciousNodes.Count == 1)
             {
@@ -3083,9 +3191,9 @@ namespace Musoq.Evaluator.Visitors
                         SyntaxKind.LogicalAndExpression,
                         SyntaxFactory.BinaryExpression(
                             SyntaxKind.NotEqualsExpression,
-                            (ExpressionSyntax)NullSuspiciousNodes.Pop(),
+                            (ExpressionSyntax) NullSuspiciousNodes.Pop(),
                             SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)),
-                        (BinaryExpressionSyntax)rawNode));
+                        (BinaryExpressionSyntax) rawNode));
             }
 
             return rawNode;
@@ -3126,13 +3234,13 @@ namespace Musoq.Evaluator.Visitors
             var then = Nodes.Pop();
             var when = Nodes.Pop();
 
-            var ifStatement = 
+            var ifStatement =
                 SyntaxFactory.IfStatement(
-                    (ExpressionSyntax)when,
+                    (ExpressionSyntax) when,
                     SyntaxFactory.Block(
                         SyntaxFactory.SingletonList<StatementSyntax>(
                             SyntaxFactory.ReturnStatement(
-                                (ExpressionSyntax)then))));
+                                (ExpressionSyntax) then))));
 
             var ifStatements = new List<IfStatementSyntax>
             {
@@ -3146,30 +3254,30 @@ namespace Musoq.Evaluator.Visitors
                 when = Nodes.Pop();
 
                 ifStatements.Add(
-                        SyntaxFactory.IfStatement(
-                            (ExpressionSyntax)when,
-                            SyntaxFactory.Block(
-                                SyntaxFactory.SingletonList<StatementSyntax>(
+                    SyntaxFactory.IfStatement(
+                        (ExpressionSyntax) when,
+                        SyntaxFactory.Block(
+                            SyntaxFactory.SingletonList<StatementSyntax>(
                                 SyntaxFactory.ReturnStatement(
-                                    (ExpressionSyntax)then)))));
+                                    (ExpressionSyntax) then)))));
             }
 
             var elseNode = Nodes.Pop();
 
-            ifStatements[^1] = 
+            ifStatements[^1] =
                 ifStatements[^1].WithElse(
                     SyntaxFactory.ElseClause(
                         SyntaxFactory.Block(
-                                SyntaxFactory.SingletonList<StatementSyntax>(
+                            SyntaxFactory.SingletonList<StatementSyntax>(
                                 SyntaxFactory.ReturnStatement(
-                                    (ExpressionSyntax)elseNode)))));
+                                    (ExpressionSyntax) elseNode)))));
 
             IfStatementSyntax first;
             IfStatementSyntax second;
 
             IfStatementSyntax newIfStatement = null;
 
-            for(var i = ifStatements.Count - 2; i >= 1; i-=1)
+            for (var i = ifStatements.Count - 2; i >= 1; i -= 1)
             {
                 first = ifStatements[i];
                 second = ifStatements[i + 1];
@@ -3177,14 +3285,14 @@ namespace Musoq.Evaluator.Visitors
                 ifStatements.RemoveAt(i + 1);
                 ifStatements.RemoveAt(i);
 
-                newIfStatement = 
+                newIfStatement =
                     first.WithElse(
                         SyntaxFactory.ElseClause(second));
 
                 ifStatements.Add(newIfStatement);
             }
 
-            if(ifStatements.Count == 2)
+            if (ifStatements.Count == 2)
             {
                 first = ifStatements[0];
                 second = ifStatements[1];
@@ -3216,9 +3324,9 @@ namespace Musoq.Evaluator.Visitors
             parameters.Add(
                 SyntaxFactory.Parameter(
                     SyntaxFactory.Identifier("score")
-            ).WithType(
-                  SyntaxFactory.IdentifierName(nameof(IObjectResolver))
-            ));
+                ).WithType(
+                    SyntaxFactory.IdentifierName(nameof(IObjectResolver))
+                ));
 
             var rowVariableName = string.Empty;
             switch (_oldType)
@@ -3230,6 +3338,7 @@ namespace Musoq.Evaluator.Visitors
                     rowVariableName = "score";
                     break;
             }
+
             callParameters.Add(
                 SyntaxFactory.Argument(
                     SyntaxFactory.IdentifierName(rowVariableName)));
@@ -3239,7 +3348,7 @@ namespace Musoq.Evaluator.Visitors
                 parameters.Add(
                     SyntaxFactory.Parameter(
                         SyntaxFactory.Identifier(variableNameTypePair.Key)
-                    ).WithType (
+                    ).WithType(
                         SyntaxFactory.IdentifierName(variableNameTypePair.Value.Name)
                     ));
 

--- a/Musoq.Parser/Helpers/NodeHelper.cs
+++ b/Musoq.Parser/Helpers/NodeHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Musoq.Schema.Helpers;
 
 namespace Musoq.Parser.Helpers
 {
@@ -51,6 +50,15 @@ namespace Musoq.Parser.Helpers
         public static Type GetReturnTypeMap(Type left, Type right)
         {
             return BinaryTypes[(left.GetUnderlyingNullable(), right.GetUnderlyingNullable())];
+        }
+        
+        private static Type GetUnderlyingNullable(this Type type)
+        {
+            var nullableType = Nullable.GetUnderlyingType(type);
+
+            var isNullableType = nullableType != null;
+
+            return isNullableType ? nullableType : type;
         }
     }
 }

--- a/Musoq.Parser/IExpressionVisitor.cs
+++ b/Musoq.Parser/IExpressionVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Parser
 {

--- a/Musoq.Parser/Musoq.Parser.csproj
+++ b/Musoq.Parser/Musoq.Parser.csproj
@@ -19,9 +19,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-
-  <ItemGroup>
-    <ProjectReference Include="..\Musoq.Schema\Musoq.Schema.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/Musoq.Parser/Musoq.Parser.csproj
+++ b/Musoq.Parser/Musoq.Parser.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.1</Version>
+    <Version>2.2</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Parser/Nodes/AccessMethodNode.cs
+++ b/Musoq.Parser/Nodes/AccessMethodNode.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Musoq.Parser.Tokens;
-using Musoq.Plugins.Attributes;
 
 namespace Musoq.Parser.Nodes
 {
@@ -11,7 +10,7 @@ namespace Musoq.Parser.Nodes
         public readonly FunctionToken FToken;
 
         public AccessMethodNode(FunctionToken fToken, ArgsListNode args, ArgsListNode extraAggregateArguments, bool canSkipInjectSource,
-            MethodInfo method = (MethodInfo) null, string alias = "")
+            MethodInfo method = null, string alias = "")
         {
             FToken = fToken;
             Arguments = args;
@@ -31,9 +30,6 @@ namespace Musoq.Parser.Nodes
         public string Name => FToken.Value;
 
         public string Alias { get; }
-
-        public bool IsAggregateMethod =>
-            Method != null && Method.GetCustomAttribute<AggregationMethodAttribute>() != null;
 
         public ArgsListNode ExtraAggregateArguments { get; }
 

--- a/Musoq.Parser/Nodes/ArgsListNode.cs
+++ b/Musoq.Parser/Nodes/ArgsListNode.cs
@@ -33,5 +33,13 @@ namespace Musoq.Parser.Nodes
                 : Args.Select(f => f.ToString()).Aggregate((a, b) => $"{a.ToString()}, {b.ToString()}");
             return str;
         }
+        
+        public string ToStringWithBrackets()
+        {
+            var str = Args.Length == 0
+                ? string.Empty
+                : Args.Select(f => f.ToString()).Aggregate((a, b) => $"{a.ToString()}, {b.ToString()}");
+            return $"({str})";
+        }
     }
 }

--- a/Musoq.Parser/Nodes/ContainsNode.cs
+++ b/Musoq.Parser/Nodes/ContainsNode.cs
@@ -20,7 +20,7 @@
 
         public override string ToString()
         {
-            return $"{Left.ToString()} contains {Right.ToString()}";
+            return $"{Left.ToString()} contains {ToCompareExpression.ToStringWithBrackets()}";
         }
     }
 }

--- a/Musoq.Parser/Nodes/CoupleNode.cs
+++ b/Musoq.Parser/Nodes/CoupleNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Parser.Nodes
 {

--- a/Musoq.Parser/Nodes/From/AliasedFromNode.cs
+++ b/Musoq.Parser/Nodes/From/AliasedFromNode.cs
@@ -1,9 +1,18 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class AliasedFromNode : FromNode
     {
-        public AliasedFromNode(string identifier, ArgsListNode args, string alias)
+        internal AliasedFromNode(string identifier, ArgsListNode args, string alias)
             : base(alias)
+        {
+            Identifier = identifier;
+            Args = args;
+        }
+        
+        public AliasedFromNode(string identifier, ArgsListNode args, string alias, Type returnType)
+            : base(alias, returnType)
         {
             Identifier = identifier;
             Args = args;

--- a/Musoq.Parser/Nodes/From/ExpressionFromNode.cs
+++ b/Musoq.Parser/Nodes/From/ExpressionFromNode.cs
@@ -1,9 +1,18 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class ExpressionFromNode : FromNode
     {
-        public ExpressionFromNode(FromNode from)
+        internal ExpressionFromNode(FromNode from)
             : base(from.Alias)
+        {
+            Expression = from;
+            Id = $"{nameof(ExpressionFromNode)}{from.ToString()}";
+        }
+        
+        public ExpressionFromNode(FromNode from, Type returnType)
+            : base(from.Alias, returnType)
         {
             Expression = from;
             Id = $"{nameof(ExpressionFromNode)}{from.ToString()}";

--- a/Musoq.Parser/Nodes/From/InMemoryGroupedFromNode.cs
+++ b/Musoq.Parser/Nodes/From/InMemoryGroupedFromNode.cs
@@ -1,9 +1,17 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class InMemoryGroupedFromNode : FromNode
     {
-        public InMemoryGroupedFromNode(string alias)
+        internal InMemoryGroupedFromNode(string alias)
             : base(alias)
+        {
+            Id = $"{nameof(InMemoryTableFromNode)}{Alias}";
+        }
+        
+        public InMemoryGroupedFromNode(string alias, Type returnType)
+            : base(alias, returnType)
         {
             Id = $"{nameof(InMemoryTableFromNode)}{Alias}";
         }

--- a/Musoq.Parser/Nodes/From/InMemoryTableFromNode.cs
+++ b/Musoq.Parser/Nodes/From/InMemoryTableFromNode.cs
@@ -1,9 +1,17 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class InMemoryTableFromNode : FromNode
     {
-        public InMemoryTableFromNode(string variableName, string alias)
+        internal InMemoryTableFromNode(string variableName, string alias)
             : base(alias)
+        {
+            VariableName = variableName;
+        }
+        
+        public InMemoryTableFromNode(string variableName, string alias, Type returnType)
+            : base(alias, returnType)
         {
             VariableName = variableName;
         }

--- a/Musoq.Parser/Nodes/From/JoinFromNode.cs
+++ b/Musoq.Parser/Nodes/From/JoinFromNode.cs
@@ -1,9 +1,20 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class JoinFromNode : FromNode
     {
-        public JoinFromNode(FromNode joinFrom, FromNode from, Node expression, JoinType joinType)
+        internal JoinFromNode(FromNode joinFrom, FromNode from, Node expression, JoinType joinType)
             : base($"{joinFrom.Alias}{from.Alias}")
+        {
+            Source = joinFrom;
+            With = from;
+            Expression = expression;
+            JoinType = joinType;
+        }
+        
+        public JoinFromNode(FromNode joinFrom, FromNode from, Node expression, JoinType joinType, Type returnType)
+            : base($"{joinFrom.Alias}{from.Alias}", returnType)
         {
             Source = joinFrom;
             With = from;

--- a/Musoq.Parser/Nodes/From/JoinInMemoryWithSourceTableFromNode.cs
+++ b/Musoq.Parser/Nodes/From/JoinInMemoryWithSourceTableFromNode.cs
@@ -1,9 +1,22 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class JoinInMemoryWithSourceTableFromNode : FromNode
     {
-        public JoinInMemoryWithSourceTableFromNode(string inMemoryTableAlias, FromNode sourceTable, Node expression, JoinType joinType)
+        internal JoinInMemoryWithSourceTableFromNode(string inMemoryTableAlias, FromNode sourceTable, Node expression, JoinType joinType)
             : base($"{inMemoryTableAlias}{sourceTable.Alias}")
+        {
+            Id =
+                $"{nameof(JoinInMemoryWithSourceTableFromNode)}{inMemoryTableAlias}{sourceTable.Alias}{expression.ToString()}";
+            InMemoryTableAlias = inMemoryTableAlias;
+            SourceTable = sourceTable;
+            Expression = expression;
+            JoinType = joinType;
+        }
+        
+        public JoinInMemoryWithSourceTableFromNode(string inMemoryTableAlias, FromNode sourceTable, Node expression, JoinType joinType, Type returnType)
+            : base($"{inMemoryTableAlias}{sourceTable.Alias}", returnType)
         {
             Id =
                 $"{nameof(JoinInMemoryWithSourceTableFromNode)}{inMemoryTableAlias}{sourceTable.Alias}{expression.ToString()}";

--- a/Musoq.Parser/Nodes/From/JoinSourcesTableFromNode.cs
+++ b/Musoq.Parser/Nodes/From/JoinSourcesTableFromNode.cs
@@ -1,9 +1,21 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class JoinSourcesTableFromNode : FromNode
     {
-        public JoinSourcesTableFromNode(FromNode first, FromNode second, Node expression, JoinType joinType)
+        internal JoinSourcesTableFromNode(FromNode first, FromNode second, Node expression, JoinType joinType)
             : base($"{first.Alias}{second.Alias}")
+        {
+            Id = $"{nameof(JoinSourcesTableFromNode)}{Alias}{expression.ToString()}";
+            First = first;
+            Second = second;
+            Expression = expression;
+            JoinType = joinType;
+        }
+        
+        public JoinSourcesTableFromNode(FromNode first, FromNode second, Node expression, JoinType joinType, Type returnType)
+            : base($"{first.Alias}{second.Alias}", returnType)
         {
             Id = $"{nameof(JoinSourcesTableFromNode)}{Alias}{expression.ToString()}";
             First = first;

--- a/Musoq.Parser/Nodes/From/JoinsNode.cs
+++ b/Musoq.Parser/Nodes/From/JoinsNode.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 
-namespace Musoq.Parser.Nodes
+namespace Musoq.Parser.Nodes.From
 {
     public class JoinsNode : FromNode
     {
-        public JoinsNode(JoinFromNode joins)
+        internal JoinsNode(JoinFromNode joins)
             : base(joins.Alias)
+        {
+            Id = $"{nameof(JoinsNode)}{joins.Id}";
+            Joins = joins;
+        }
+        
+        public JoinsNode(JoinFromNode joins, Type returnType)
+            : base(joins.Alias, returnType)
         {
             Id = $"{nameof(JoinsNode)}{joins.Id}";
             Joins = joins;

--- a/Musoq.Parser/Nodes/From/ReferentialFromNode.cs
+++ b/Musoq.Parser/Nodes/From/ReferentialFromNode.cs
@@ -1,9 +1,17 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class ReferentialFromNode : FromNode
     {
-        public ReferentialFromNode(string name, string alias)
+        internal ReferentialFromNode(string name, string alias)
             : base(alias)
+        {
+            Name = name;
+        }
+        
+        public ReferentialFromNode(string name, string alias, Type returnType)
+            : base(alias, returnType)
         {
             Name = name;
         }

--- a/Musoq.Parser/Nodes/From/SchemaFromNode.cs
+++ b/Musoq.Parser/Nodes/From/SchemaFromNode.cs
@@ -1,9 +1,21 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class SchemaFromNode : FromNode
     {
-        public SchemaFromNode(string schema, string method, ArgsListNode parameters, string alias)
+        internal SchemaFromNode(string schema, string method, ArgsListNode parameters, string alias)
             : base(alias)
+        {
+            Schema = schema;
+            Method = method;
+            Parameters = parameters;
+            var paramsId = parameters.Id;
+            Id = $"{nameof(SchemaFromNode)}{schema}{method}{paramsId}{Alias}";
+        }
+        
+        public SchemaFromNode(string schema, string method, ArgsListNode parameters, string alias, Type returnType)
+            : base(alias, returnType)
         {
             Schema = schema;
             Method = method;

--- a/Musoq.Parser/Nodes/From/SchemaMethodFromNode.cs
+++ b/Musoq.Parser/Nodes/From/SchemaMethodFromNode.cs
@@ -1,9 +1,19 @@
-﻿namespace Musoq.Parser.Nodes
+﻿using System;
+
+namespace Musoq.Parser.Nodes.From
 {
     public class SchemaMethodFromNode : FromNode
     {
-        public SchemaMethodFromNode(string schema, string method)
+        internal SchemaMethodFromNode(string schema, string method)
             : base(string.Empty)
+        {
+            Schema = schema;
+            Method = method;
+            Id = $"{nameof(SchemaMethodFromNode)}{schema}{method}";
+        }
+        
+        public SchemaMethodFromNode(string schema, string method, Type returnType)
+            : base(string.Empty, returnType)
         {
             Schema = schema;
             Method = method;

--- a/Musoq.Parser/Nodes/FromNode.cs
+++ b/Musoq.Parser/Nodes/FromNode.cs
@@ -1,17 +1,26 @@
-﻿using System;
-using Musoq.Schema.DataSources;
+﻿#nullable enable
+using System;
 
 namespace Musoq.Parser.Nodes
 {
     public abstract class FromNode : Node
     {
+        private readonly Type? _returnType;
+        
         protected FromNode(string alias)
         {
             Alias = alias;
+            _returnType = null;
+        }
+        
+        protected FromNode(string alias, Type returnType)
+        {
+            Alias = alias;
+            _returnType = returnType;
         }
 
         public virtual string Alias { get; }
 
-        public override Type ReturnType => typeof(RowSource);
+        public override Type ReturnType => _returnType ?? throw new InvalidOperationException("Return type is not set.");
     }
 }

--- a/Musoq.Parser/Nodes/InNode.cs
+++ b/Musoq.Parser/Nodes/InNode.cs
@@ -4,7 +4,8 @@ namespace Musoq.Parser.Nodes
 {
     public class InNode : BinaryNode
     {
-        public InNode(Node left, ArgsListNode right) : base(left, right)
+        public InNode(Node left, ArgsListNode right) 
+            : base(left, right)
         {
             Id = CalculateId(this);
         }

--- a/Musoq.Parser/Parser.cs
+++ b/Musoq.Parser/Parser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Musoq.Parser.Lexing;
 using Musoq.Parser.Nodes;
+using Musoq.Parser.Nodes.From;
 using Musoq.Parser.Tokens;
 
 namespace Musoq.Parser
@@ -297,7 +298,7 @@ namespace Musoq.Parser
             fromNode = ComposeJoin(fromNode);
 
             var whereNode = ComposeWhere(false);
-            var groupBy = ComposeGrouByNode();
+            var groupBy = ComposeGroupByNode();
             var orderBy = ComposeOrderBy();
             var skip = ComposeSkip();
             var take = ComposeTake();
@@ -309,7 +310,7 @@ namespace Musoq.Parser
             var fromNode = ComposeFrom();
             fromNode = ComposeJoin(fromNode);
             var whereNode = ComposeWhere(false);
-            var groupBy = ComposeGrouByNode();
+            var groupBy = ComposeGroupByNode();
             var selectNode = ComposeSelectNode();
             var orderBy = ComposeOrderBy();
             var skip = ComposeSkip();
@@ -382,7 +383,7 @@ namespace Musoq.Parser
             return null;
         }
 
-        private GroupByNode ComposeGrouByNode()
+        private GroupByNode ComposeGroupByNode()
         {
             if (Current.TokenType == TokenType.GroupBy)
             {

--- a/Musoq.Plugins/Musoq.Plugins.csproj
+++ b/Musoq.Plugins/Musoq.Plugins.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Schema/DataSources/SchemaBase.cs
+++ b/Musoq.Schema/DataSources/SchemaBase.cs
@@ -61,8 +61,8 @@ namespace Musoq.Schema.DataSources
 
             var methods = GetConstructors(sourceName).Select(c => c.ConstructorInfo).ToArray();
 
-            if (AdditionalArguments.ContainsKey(sourceName))
-                parameters = parameters.ExpandParameters(AdditionalArguments[sourceName]);
+            if (AdditionalArguments.TryGetValue(sourceName, out var argument))
+                parameters = parameters.ExpandParameters(argument);
 
             if (!TryMatchConstructorWithParams(methods, parameters, out var constructorInfo))
                 throw new NotSupportedException($"Unrecognized method {name}.");

--- a/Musoq.Schema/Musoq.Schema.csproj
+++ b/Musoq.Schema/Musoq.Schema.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Musoq.Plugins\Musoq.Plugins.csproj" >
+    <ProjectReference Include="..\Musoq.Parser\Musoq.Parser.csproj" />
+    <ProjectReference Include="..\Musoq.Plugins\Musoq.Plugins.csproj">
       <ExcludeAssets>runtime</ExcludeAssets>
       <Private>false</Private>
     </ProjectReference>

--- a/Musoq.Schema/Musoq.Schema.csproj
+++ b/Musoq.Schema/Musoq.Schema.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Schema/RuntimeContext.cs
+++ b/Musoq.Schema/RuntimeContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
+using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Schema
 {
@@ -11,14 +12,14 @@ namespace Musoq.Schema
         
         public IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
 
-        public IReadOnlyCollection<ISchemaColumn> UsedColumns { get; }
+        public (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns) QueryInformation { get; }
 
-        public RuntimeContext(CancellationToken endWorkToken, IReadOnlyCollection<ISchemaColumn> originallyInferredColumns, IReadOnlyDictionary<string, string> environmentVariables, IReadOnlyCollection<ISchemaColumn> usedColumns = null)
+        public RuntimeContext(CancellationToken endWorkToken, IReadOnlyCollection<ISchemaColumn> originallyInferredColumns, IReadOnlyDictionary<string, string> environmentVariables, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns) queryInformation)
         {
             EndWorkToken = endWorkToken;
             AllColumns = originallyInferredColumns;
             EnvironmentVariables = environmentVariables;
-            UsedColumns = usedColumns;
+            QueryInformation = queryInformation;
         }
     }
 }

--- a/Musoq.Schema/RuntimeContext.cs
+++ b/Musoq.Schema/RuntimeContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
+using Musoq.Parser.Nodes;
 using Musoq.Parser.Nodes.From;
 
 namespace Musoq.Schema
@@ -12,9 +13,9 @@ namespace Musoq.Schema
         
         public IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
 
-        public (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns) QueryInformation { get; }
+        public (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns, WhereNode WhereNode) QueryInformation { get; }
 
-        public RuntimeContext(CancellationToken endWorkToken, IReadOnlyCollection<ISchemaColumn> originallyInferredColumns, IReadOnlyDictionary<string, string> environmentVariables, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns) queryInformation)
+        public RuntimeContext(CancellationToken endWorkToken, IReadOnlyCollection<ISchemaColumn> originallyInferredColumns, IReadOnlyDictionary<string, string> environmentVariables, (SchemaFromNode FromNode, IReadOnlyCollection<ISchemaColumn> Columns, WhereNode WhereNode) queryInformation)
         {
             EndWorkToken = endWorkToken;
             AllColumns = originallyInferredColumns;


### PR DESCRIPTION
Data Source will now have ability to preliminary filter what data are loaded because:

1. It will have access to all the columns used in the query
2. It will have access to where filter suited to the query to for example effectivelly use indexes