### PR TITLE
Various fixes

### DIFF
--- a/Musoq.Evaluator.Tests/AliasTests.cs
+++ b/Musoq.Evaluator.Tests/AliasTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Musoq.Evaluator.Exceptions;
 using Musoq.Evaluator.Tests.Schema.Multi;
 
 namespace Musoq.Evaluator.Tests;
@@ -24,6 +25,18 @@ public class AliasTests : MultiSchemaTestBase
         Assert.AreEqual(1, table.Columns.Count());
         
         Assert.AreEqual("ZeroItem", table.Columns.ElementAt(0).ColumnName);
+    }
+    
+    [TestMethod]
+    public void WhenNonExistingAliasUsed_ShouldThrow()
+    {
+        const string query = "select b.ZeroItem from #schema.first() a";
+        
+        Assert.ThrowsException<UnknownColumnOrAliasException>(() => CreateAndRunVirtualMachine(query, [
+            new()
+        ], [
+            new()
+        ]));
     }
     
     [TestMethod]

--- a/Musoq.Evaluator.Tests/DateTimeOffsetTests.cs
+++ b/Musoq.Evaluator.Tests/DateTimeOffsetTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Musoq.Evaluator.Tests.Schema.Unknown;
+
+namespace Musoq.Evaluator.Tests;
+
+[TestClass]
+public class DateTimeOffsetTests : UnknownQueryTestsBase
+{
+    [TestMethod]
+    public void MinDateTimeOffsetTest()
+    {
+        const string query = "table Dates {" +
+                             "  Date 'System.DateTimeOffset'" +
+                             "};" +
+                             "couple #test.whatever with table Dates as Dates; " +
+                             "select MinDateTimeOffset(Date) from Dates()";
+        
+        dynamic first = new ExpandoObject();
+        first.Date = new DateTimeOffset(new DateTime(2023, 1, 1));
+        
+        dynamic second = new ExpandoObject();
+        second.Date = new DateTimeOffset(new DateTime(2023, 2, 1));
+        
+        var vm = CreateAndRunVirtualMachine(query, new List<dynamic>
+        {
+            first, second
+        });
+        
+        var table = vm.Run();
+        
+        Assert.AreEqual(1, table.Columns.Count());
+        Assert.AreEqual("MinDateTimeOffset(Date)", table.Columns.ElementAt(0).ColumnName);
+        Assert.AreEqual(typeof(DateTimeOffset?), table.Columns.ElementAt(0).ColumnType);
+        
+        Assert.AreEqual(1, table.Count);
+        Assert.AreEqual(new DateTimeOffset(new DateTime(2023, 1, 1)), table[0].Values[0]);
+    }
+
+    [TestMethod]
+    public void MaxDateTimeOffsetTest()
+    {
+        const string query = "table Dates {" +
+                             "  Date 'System.DateTimeOffset'" +
+                             "};" +
+                             "couple #test.whatever with table Dates as Dates; " +
+                             "select MaxDateTimeOffset(Date) from Dates()";
+        
+        dynamic first = new ExpandoObject();
+        first.Date = new DateTimeOffset(new DateTime(2023, 1, 1));
+        
+        dynamic second = new ExpandoObject();
+        second.Date = new DateTimeOffset(new DateTime(2023, 2, 1));
+        
+        var vm = CreateAndRunVirtualMachine(query, new List<dynamic>
+        {
+            first, second
+        });
+        
+        var table = vm.Run();
+        
+        Assert.AreEqual(1, table.Columns.Count());
+        Assert.AreEqual("MaxDateTimeOffset(Date)", table.Columns.ElementAt(0).ColumnName);
+        Assert.AreEqual(typeof(DateTimeOffset?), table.Columns.ElementAt(0).ColumnType);
+        
+        Assert.AreEqual(1, table.Count);
+        Assert.AreEqual(new DateTimeOffset(new DateTime(2023, 2, 1)), table[0].Values[0]);
+    }
+}

--- a/Musoq.Evaluator.Tests/GroupByTests.cs
+++ b/Musoq.Evaluator.Tests/GroupByTests.cs
@@ -419,7 +419,15 @@ public class GroupByTests : BasicEntityTestBase
     public void GroupByColumnSubstringTest()
     {
         var query =
-            "select Country, Substring(City, IndexOf(City, ':')) as 'City', Count(City) as 'Count', Sum(Population) as 'Sum' from #A.Entities() group by Substring(City, IndexOf(City, ':')), Country";
+            """
+select 
+    Country, 
+    Substring(City, IndexOf(City, ':')) as 'City', 
+    Count(City) as 'Count', 
+    Sum(Population) as 'Sum' 
+from #A.Entities() 
+group by Substring(City, IndexOf(City, ':')), Country
+""";
 
         var sources = new Dictionary<string, IEnumerable<BasicEntity>>
         {

--- a/Musoq.Evaluator.Tests/JoinTests.cs
+++ b/Musoq.Evaluator.Tests/JoinTests.cs
@@ -326,6 +326,82 @@ group by cities.Country";
         Assert.AreEqual("Germany", table[1][0]);
         Assert.AreEqual(400m, table[1][1]);
     }
+    
+    [TestMethod]
+    public void JoinWithGroupByAndOrderByTest()
+    {
+        var query = @"
+select 
+    cities.GetTypeName(cities.Country)
+from #A.entities() countries 
+inner join #B.entities() cities on countries.Country = cities.Country
+group by cities.GetTypeName(cities.Country)
+order by cities.GetTypeName(cities.Country)";
+
+        var sources = new Dictionary<string, IEnumerable<BasicEntity>>
+        {
+            {
+                "#A", [
+                    new BasicEntity("Poland", "Krakow"),
+                    new BasicEntity("Germany", "Berlin")
+                ]
+            },
+            {
+                "#B", [
+                    new BasicEntity("Poland", "Krakow"),
+                    new BasicEntity("Poland", "Wroclaw"),
+                    new BasicEntity("Poland", "Warszawa"),
+                    new BasicEntity("Poland", "Gdansk"),
+                    new BasicEntity("Germany", "Berlin")
+                ]
+            },
+        };
+
+        var vm = CreateAndRunVirtualMachine(query, sources);
+        var table = vm.Run();
+        
+        Assert.AreEqual(1, table.Columns.Count());
+        
+        Assert.AreEqual("GetTypeName(cities.Country)", table.Columns.ElementAt(0).ColumnName);
+        Assert.AreEqual(typeof(string), table.Columns.ElementAt(0).ColumnType);
+        
+        Assert.AreEqual(1, table.Count);
+        
+        Assert.AreEqual("System.String", table[0][0]);
+    }
+    
+    [TestMethod]
+    public void JoinWithOrderByTest()
+    {
+        var query = @"
+select 
+    cities.Country
+from #A.entities() countries 
+inner join #B.entities() cities on countries.Country = cities.Country
+order by cities.GetTypeName(cities.Country)";
+
+        var sources = new Dictionary<string, IEnumerable<BasicEntity>>
+        {
+            {
+                "#A", [
+                    new BasicEntity("Poland", "Krakow"),
+                    new BasicEntity("Germany", "Berlin")
+                ]
+            },
+            {
+                "#B", [
+                    new BasicEntity("Poland", "Krakow"),
+                    new BasicEntity("Poland", "Wroclaw"),
+                    new BasicEntity("Poland", "Warszawa"),
+                    new BasicEntity("Poland", "Gdansk"),
+                    new BasicEntity("Germany", "Berlin")
+                ]
+            },
+        };
+
+        var vm = CreateAndRunVirtualMachine(query, sources);
+        var table = vm.Run();
+    }
 
     [TestMethod]
     public void JoinWithExceptTest()
@@ -784,7 +860,7 @@ select p.Country, p.Count(p.Country) from p inner join x on p.Country = x.Countr
         Assert.AreEqual(typeof(int?), column.ColumnType);
 
         Assert.AreEqual(1, table[0][0]);
-        Assert.AreEqual((int?)null, table[0][1]);
+        Assert.AreEqual(null, table[0][1]);
     }
 
     [TestMethod]

--- a/Musoq.Evaluator.Tests/OrderByTests.cs
+++ b/Musoq.Evaluator.Tests/OrderByTests.cs
@@ -762,4 +762,32 @@ public class OrderByTests : BasicEntityTestBase
         Assert.AreEqual("czestochowa", table[2].Values[0]);
         Assert.AreEqual("cracow", table[3].Values[0]);
     }
+
+    [TestMethod]
+    public void WhenOrderByWithGroupBy_ShouldSucceed()
+    {
+        const string query = """
+                             select 
+                                GetTypeName(a.Name),
+                                Count(a.Name)
+                             from #A.Entities() a
+                             group by GetTypeName(a.Name)
+                             order by GetTypeName(a.Name)
+                             """;
+        var sources = new Dictionary<string, IEnumerable<BasicEntity>>
+        {
+            {
+                "#A", [new BasicEntity("a"), new BasicEntity("b"), new BasicEntity("c")]
+            }
+        };
+        
+        var vm = CreateAndRunVirtualMachine(query, sources);
+        
+        var table = vm.Run();
+        
+        Assert.AreEqual(1, table.Count);
+        
+        Assert.AreEqual("System.String", table[0].Values[0]);
+        Assert.AreEqual(3, table[0].Values[1]);
+    }
 }

--- a/Musoq.Evaluator.Tests/SingleSchemaEvaluatorTests.cs
+++ b/Musoq.Evaluator.Tests/SingleSchemaEvaluatorTests.cs
@@ -98,7 +98,7 @@ public class SingleSchemaEvaluatorTests : BasicEntityTestBase
             }
         };
 
-        Assert.ThrowsException<UnknownColumnException>(() => CreateAndRunVirtualMachine(query, sources));
+        Assert.ThrowsException<UnknownColumnOrAliasException>(() => CreateAndRunVirtualMachine(query, sources));
     }
 
     [TestMethod]
@@ -232,7 +232,7 @@ public class SingleSchemaEvaluatorTests : BasicEntityTestBase
             }
         };
 
-        Assert.ThrowsException<UnknownColumnException>(() => CreateAndRunVirtualMachine(query, sources));
+        Assert.ThrowsException<UnknownColumnOrAliasException>(() => CreateAndRunVirtualMachine(query, sources));
     }
 
     [TestMethod]

--- a/Musoq.Evaluator/Exceptions/UnknownColumnException.cs
+++ b/Musoq.Evaluator/Exceptions/UnknownColumnException.cs
@@ -1,5 +1,0 @@
-﻿using System;
-
-namespace Musoq.Evaluator.Exceptions;
-
-public class UnknownColumnException(string message) : Exception(message);

--- a/Musoq.Evaluator/Exceptions/UnknownColumnOrAliasException.cs
+++ b/Musoq.Evaluator/Exceptions/UnknownColumnOrAliasException.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace Musoq.Evaluator.Exceptions;
+
+public class UnknownColumnOrAliasException(string message) : Exception(message);

--- a/Musoq.Evaluator/Helpers/EvaluationHelper.cs
+++ b/Musoq.Evaluator/Helpers/EvaluationHelper.cs
@@ -150,11 +150,11 @@ public static class EvaluationHelper
         return output;
     }
 
-    public static string GetCasteableType(Type type)
+    public static string GetCastableType(Type type)
     {
         if (type is NullNode.NullType) return "System.Object";
         if (type.IsGenericType) return GetFriendlyTypeName(type);
-        if (type.IsNested) return $"{GetCasteableType(type.DeclaringType)}.{type.Name}";
+        if (type.IsNested) return $"{GetCastableType(type.DeclaringType)}.{type.Name}";
 
         return ReplacePlusWithDotForNestedClasses(type.FullName);
     }

--- a/Musoq.Evaluator/Musoq.Evaluator.csproj
+++ b/Musoq.Evaluator/Musoq.Evaluator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>7.4.2</Version>
+    <Version>7.4.3</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>
@@ -43,10 +43,10 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>MetaAttributes.resx</DependentUpon>
     </Compile>
-    <Compile Update="Visitors\RewriteFieldOrderedWithGroupMethodCall.cs">
+    <Compile Update="Visitors\RewriteFieldWithGroupMethodCall.cs">
       <DependentUpon>RewriteFieldWithGroupMethodCallBase.cs</DependentUpon>
     </Compile>
-    <Compile Update="Visitors\RewriteFieldWithGroupMethodCall.cs">
+    <Compile Update="Visitors\RewriteFieldOrderedWithGroupMethodCall.cs">
       <DependentUpon>RewriteFieldWithGroupMethodCallBase.cs</DependentUpon>
     </Compile>
   </ItemGroup>

--- a/Musoq.Evaluator/Parser/PropertyFromNode.cs
+++ b/Musoq.Evaluator/Parser/PropertyFromNode.cs
@@ -1,11 +1,7 @@
-﻿using System;
+﻿namespace Musoq.Evaluator.Parser;
 
-namespace Musoq.Evaluator.Parser;
-
-public class PropertyFromNode : Musoq.Parser.Nodes.From.PropertyFromNode
-{
-    public PropertyFromNode(string alias, string sourceAlias, string propertyName, Type returnType) 
-        : base(alias, sourceAlias, propertyName, returnType)
-    {
-    }
-}
+public class PropertyFromNode(
+    string alias,
+    string sourceAlias,
+    Musoq.Parser.Nodes.From.PropertyFromNode.PropertyNameAndTypePair[] properties)
+    : Musoq.Parser.Nodes.From.PropertyFromNode(alias, sourceAlias, properties);

--- a/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
+++ b/Musoq.Evaluator/Visitors/CloneQueryVisitor.cs
@@ -218,7 +218,7 @@ public class CloneQueryVisitor : IExpressionVisitor
 
     public virtual void Visit(AccessMethodNode node)
     {
-        Nodes.Push(new AccessMethodNode(node.FToken, (ArgsListNode) Nodes.Pop(), null, node.CanSkipInjectSource, node.Method, node.Alias));
+        Nodes.Push(new AccessMethodNode(node.FunctionToken, (ArgsListNode) Nodes.Pop(), null, node.CanSkipInjectSource, node.Method, node.Alias));
     }
 
     public virtual void Visit(AccessRawIdentifierNode node)
@@ -382,7 +382,7 @@ public class CloneQueryVisitor : IExpressionVisitor
 
     public virtual void Visit(PropertyFromNode node)
     {
-        Nodes.Push(new Parser.PropertyFromNode(node.Alias, node.SourceAlias, node.PropertyName, node.ReturnType));
+        Nodes.Push(new Parser.PropertyFromNode(node.Alias, node.SourceAlias, node.PropertiesChain));
     }
 
     public virtual void Visit(AliasedFromNode node)

--- a/Musoq.Evaluator/Visitors/ExtractAccessColumnFromQueryVisitor.cs
+++ b/Musoq.Evaluator/Visitors/ExtractAccessColumnFromQueryVisitor.cs
@@ -61,8 +61,8 @@ public class ExtractAccessColumnFromQueryVisitor : CloneQueryVisitor
     public override void Visit(PropertyFromNode node)
     {
         _accessColumns.TryAdd(node.SourceAlias, []);
-     
-        _accessColumns[node.SourceAlias].Add(new AccessColumnNode(node.PropertyName, node.SourceAlias, node.ReturnType, TextSpan.Empty));
+        _accessColumns[node.SourceAlias].Add(
+            new AccessColumnNode(node.FirstProperty.PropertyName, node.SourceAlias, node.ReturnType, TextSpan.Empty));
         
         base.Visit(node);
     }

--- a/Musoq.Evaluator/Visitors/RewriteFieldOrderedWithGroupMethodCall.cs
+++ b/Musoq.Evaluator/Visitors/RewriteFieldOrderedWithGroupMethodCall.cs
@@ -2,16 +2,16 @@
 
 namespace Musoq.Evaluator.Visitors;
 
-public class RewriteFieldOrderedWithGroupMethodCall : RewriteFieldWithGroupMethodCallBase<FieldOrderedNode>
+public class RewriteFieldOrderedWithGroupMethodCall(FieldNode[] nodes) : RewriteFieldWithGroupMethodCallBase<FieldOrderedNode, FieldNode>(nodes)
 {
-    public RewriteFieldOrderedWithGroupMethodCall(FieldNode[] nodes) 
-        : base(nodes)
-    {
-    }
-        
     public override void Visit(FieldOrderedNode node)
     {
         base.Visit(node);
         Expression = Nodes.Pop() as FieldOrderedNode;
+    }
+
+    protected override string ExtractOriginalExpression(FieldNode node)
+    {
+        return node.FieldName;
     }
 }

--- a/Musoq.Evaluator/Visitors/RewriteFieldWithGroupMethodCall.cs
+++ b/Musoq.Evaluator/Visitors/RewriteFieldWithGroupMethodCall.cs
@@ -2,16 +2,16 @@
 
 namespace Musoq.Evaluator.Visitors;
 
-public class RewriteFieldWithGroupMethodCall : RewriteFieldWithGroupMethodCallBase<FieldNode>
+public class RewriteFieldWithGroupMethodCall(FieldNode[] nodes) : RewriteFieldWithGroupMethodCallBase<FieldNode, FieldNode>(nodes)
 {
-    public RewriteFieldWithGroupMethodCall(FieldNode[] nodes) 
-        : base(nodes)
-    {
-    }
-        
     public override void Visit(FieldNode node)
     {
         base.Visit(node);
         Expression = Nodes.Pop() as FieldNode;
+    }
+
+    protected override string ExtractOriginalExpression(FieldNode node)
+    {
+        return node.Expression.ToString();
     }
 }

--- a/Musoq.Evaluator/Visitors/RewritePartsToUseJoinTransitionTable.cs
+++ b/Musoq.Evaluator/Visitors/RewritePartsToUseJoinTransitionTable.cs
@@ -1,17 +1,11 @@
 ﻿using Musoq.Evaluator.Helpers;
+using Musoq.Parser;
 using Musoq.Parser.Nodes;
 
 namespace Musoq.Evaluator.Visitors;
 
-public class RewritePartsToUseJoinTransitionTable : CloneQueryVisitor
+public class RewritePartsToUseJoinTransitionTable(string alias = "") : CloneQueryVisitor
 {
-    private readonly string _alias;
-
-    public RewritePartsToUseJoinTransitionTable(string alias = "")
-    {
-        _alias = alias;
-    }
-
     public SelectNode ChangedSelect { get; private set; }
         
     public GroupByNode ChangedGroupBy { get; private set; }
@@ -24,7 +18,7 @@ public class RewritePartsToUseJoinTransitionTable : CloneQueryVisitor
 
     public override void Visit(AccessColumnNode node)
     {
-        base.Visit(new AccessColumnNode(NamingHelper.ToColumnName(node.Alias, node.Name), _alias, node.ReturnType,
+        base.Visit(new AccessColumnNode(NamingHelper.ToColumnName(node.Alias, node.Name), alias, node.ReturnType,
             node.Span));
     }
 

--- a/Musoq.Evaluator/Visitors/RewriteToUpdatedColumnAccess.cs
+++ b/Musoq.Evaluator/Visitors/RewriteToUpdatedColumnAccess.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Musoq.Evaluator.Helpers;
 using Musoq.Evaluator.Parser;
 using Musoq.Parser;
@@ -54,7 +55,18 @@ public class RewriteToUpdatedColumnAccess(IReadOnlyDictionary<string, string> us
     public override void Visit(PropertyFromNode node)
     {
         base.Visit(usedTables.TryGetValue(node.SourceAlias, out var alias)
-            ? new Parser.PropertyFromNode(node.Alias, alias, NamingHelper.ToColumnName(node.SourceAlias, node.PropertyName), node.ReturnType)
+            ? new Parser.PropertyFromNode(node.Alias, alias, node.PropertiesChain.Select((p, i) =>
+            {
+                if (i == 0)
+                {
+                    return p with
+                    {
+                        PropertyName = NamingHelper.ToColumnName(node.SourceAlias, p.PropertyName)
+                    };
+                }
+
+                return p;
+            }).ToArray())
             : node);
     }
 }

--- a/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeVisitor.cs
+++ b/Musoq.Evaluator/Visitors/ToCSharpRewriteTreeVisitor.cs
@@ -363,7 +363,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
 
         var typeIdentifier =
             SyntaxFactory.IdentifierName(
-                EvaluationHelper.GetCasteableType(node.ReturnType));
+                EvaluationHelper.GetCastableType(node.ReturnType));
 
         if (node.ReturnType is NullNode.NullType)
         {
@@ -389,7 +389,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
         AddNamespace(types);
 
         var typeIdentifier = SyntaxFactory.IdentifierName(
-            EvaluationHelper.GetCasteableType(node.ReturnType));
+            EvaluationHelper.GetCastableType(node.ReturnType));
 
         if (node.ReturnType is NullNode.NullType)
         {
@@ -666,7 +666,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     }
 
                     var typeIdentifier = SyntaxFactory.IdentifierName(
-                        EvaluationHelper.GetCasteableType(parameterInfo.ParameterType));
+                        EvaluationHelper.GetCastableType(parameterInfo.ParameterType));
 
                     if (parameterInfo.ParameterType == typeof(ExpandoObject))
                     {
@@ -862,7 +862,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
 
         var typeIdentifier =
             SyntaxFactory.IdentifierName(
-                EvaluationHelper.GetCasteableType(node.ReturnType));
+                EvaluationHelper.GetCastableType(node.ReturnType));
 
         if (node.ReturnType is NullNode.NullType)
         {
@@ -1233,7 +1233,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     expressions.Add(
                         SyntaxFactory.CastExpression(
                             SyntaxFactory.IdentifierName(
-                                EvaluationHelper.GetCasteableType(column.ColumnType)),
+                                EvaluationHelper.GetCastableType(column.ColumnType)),
                             (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                 }
 
@@ -1336,7 +1336,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                         expressions.Add(
                             SyntaxFactory.CastExpression(
                                 SyntaxFactory.IdentifierName(
-                                    EvaluationHelper.GetCasteableType(column.ColumnType)),
+                                    EvaluationHelper.GetCastableType(column.ColumnType)),
                                 (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
 
                         j += 1;
@@ -1502,7 +1502,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     expressions.Add(
                         SyntaxFactory.CastExpression(
                             SyntaxFactory.IdentifierName(
-                                EvaluationHelper.GetCasteableType(column.ColumnType)),
+                                EvaluationHelper.GetCastableType(column.ColumnType)),
                             (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                 }
 
@@ -1608,7 +1608,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList([
                         SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
                             SyntaxFactory.Literal(column.ColumnName))),
-                        SyntaxHelper.TypeLiteralArgument(EvaluationHelper.GetCasteableType(column.ColumnType)),
+                        SyntaxHelper.TypeLiteralArgument(EvaluationHelper.GetCastableType(column.ColumnType)),
                         SyntaxHelper.IntLiteralArgument(column.ColumnIndex)
                     ])))).Cast<ExpressionSyntax>().ToArray()));
 
@@ -1709,7 +1709,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     expressions.Add(
                         SyntaxFactory.CastExpression(
                             SyntaxFactory.IdentifierName(
-                                EvaluationHelper.GetCasteableType(column.ColumnType)),
+                                EvaluationHelper.GetCastableType(column.ColumnType)),
                             (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                 }
 
@@ -1808,7 +1808,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                     expressions.Add(
                         SyntaxFactory.CastExpression(
                             SyntaxFactory.IdentifierName(
-                                EvaluationHelper.GetCasteableType(column.ColumnType)),
+                                EvaluationHelper.GetCastableType(column.ColumnType)),
                             (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                 }
 
@@ -1959,7 +1959,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                 {
                     expressions.Add(
                         SyntaxFactory.CastExpression(
-                            SyntaxFactory.IdentifierName(EvaluationHelper.GetCasteableType(column.ColumnType)),
+                            SyntaxFactory.IdentifierName(EvaluationHelper.GetCastableType(column.ColumnType)),
                             (LiteralExpressionSyntax) Generator.NullLiteralExpression()));
                 }
 
@@ -2109,7 +2109,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                     SyntaxFactory.Argument(
                                         SyntaxFactory.CastExpression(
                                             SyntaxFactory.ParseTypeName(
-                                                EvaluationHelper.GetCasteableType(node.ReturnType)),
+                                                EvaluationHelper.GetCastableType(node.ReturnType)),
                                             (ExpressionSyntax) Nodes.Pop())))))))))));
     }
 
@@ -2120,32 +2120,51 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
     public void Visit(PropertyFromNode node)
     {
         AddNamespace(node.ReturnType);
+        
+        ExpressionSyntax propertyAccess = SyntaxFactory.ParenthesizedExpression(
+            SyntaxFactory.CastExpression(
+                SyntaxFactory.ParseTypeName(EvaluationHelper.GetCastableType(node.PropertiesChain[0].PropertyType)),
+                SyntaxFactory.ElementAccessExpression(
+                    SyntaxFactory.IdentifierName($"{node.SourceAlias}Row"),
+                    SyntaxFactory.BracketedArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(
+                                SyntaxFactory.LiteralExpression(
+                                    SyntaxKind.StringLiteralExpression,
+                                    SyntaxFactory.Literal(node.PropertiesChain[0].PropertyName))))))));
 
-        _getRowsSourceStatement.Add(node.Alias, SyntaxFactory.LocalDeclarationStatement(SyntaxFactory
-            .VariableDeclaration(SyntaxFactory.IdentifierName("var")).WithVariables(
-                SyntaxFactory.SingletonSeparatedList(SyntaxFactory
-                    .VariableDeclarator(SyntaxFactory.Identifier(node.Alias.ToRowsSource())).WithInitializer(
-                        SyntaxFactory.EqualsValueClause(SyntaxFactory
-                            .InvocationExpression(SyntaxFactory.MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                SyntaxFactory.IdentifierName(nameof(EvaluationHelper)),
-                                SyntaxFactory.IdentifierName(nameof(EvaluationHelper.ConvertEnumerableToSource))))
+        for (var i = 1; i < node.PropertiesChain.Length; i++)
+        {
+            propertyAccess = SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                propertyAccess,
+                SyntaxFactory.IdentifierName(node.PropertiesChain[i].PropertyName));
+        }
+
+        var statement = SyntaxFactory.LocalDeclarationStatement(
+            SyntaxFactory.VariableDeclaration(
+                SyntaxFactory.IdentifierName("var"))
+            .WithVariables(
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(
+                        SyntaxFactory.Identifier(node.Alias.ToRowsSource()))
+                    .WithInitializer(
+                        SyntaxFactory.EqualsValueClause(
+                            SyntaxFactory.InvocationExpression(
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.IdentifierName(nameof(EvaluationHelper)),
+                                    SyntaxFactory.IdentifierName(nameof(EvaluationHelper.ConvertEnumerableToSource))))
                             .WithArgumentList(
-                                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
-                                    SyntaxFactory.Argument(
-                                        SyntaxFactory.CastExpression(
-                                            SyntaxFactory.ParseTypeName(
-                                                EvaluationHelper.GetCasteableType(node.ReturnType)),
-                                            SyntaxFactory.ElementAccessExpression(
-                                                    SyntaxFactory.IdentifierName($"{node.SourceAlias}Row"))
-                                                .WithArgumentList(
-                                                    SyntaxFactory.BracketedArgumentList(
-                                                        SyntaxFactory.SingletonSeparatedList(
-                                                            SyntaxFactory.Argument(
-                                                                SyntaxFactory.LiteralExpression(
-                                                                    SyntaxKind.StringLiteralExpression,
-                                                                    SyntaxFactory.Literal(
-                                                                        node.PropertyName)))))))))))))))));
+                                SyntaxFactory.ArgumentList(
+                                    SyntaxFactory.SingletonSeparatedList(
+                                        SyntaxFactory.Argument(
+                                            SyntaxFactory.CastExpression(
+                                                SyntaxFactory.ParseTypeName(
+                                                    EvaluationHelper.GetCastableType(node.ReturnType)),
+                                                propertyAccess))))))))));
+
+        _getRowsSourceStatement.Add(node.Alias, statement);
     }
 
     public void Visit(AliasedFromNode node)
@@ -2179,7 +2198,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                             $"@\"{EscapeQuoteString(field.FieldName, EscapeQuoteStringCharacter)}\"",
                                             field.FieldName))),
                                 SyntaxHelper.TypeLiteralArgument(
-                                    EvaluationHelper.GetCasteableType(type)),
+                                    EvaluationHelper.GetCastableType(type)),
                                 SyntaxHelper.IntLiteralArgument(field.FieldOrder)
                             ]))));
             }
@@ -2888,7 +2907,8 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                                             SyntaxFactory.TupleElement(
                                                                     SyntaxFactory.IdentifierName("bool"))
                                                                 .WithIdentifier(
-                                                                    SyntaxFactory.Identifier("HasExternallyProvidedTypes"))
+                                                                    SyntaxFactory.Identifier(
+                                                                        "HasExternallyProvidedTypes"))
                                                         }))
                                             })))),
 
@@ -3030,7 +3050,8 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                                             SyntaxFactory.TupleElement(
                                                                     SyntaxFactory.IdentifierName("bool"))
                                                                 .WithIdentifier(
-                                                                    SyntaxFactory.Identifier("HasExternallyProvidedTypes"))
+                                                                    SyntaxFactory.Identifier(
+                                                                        "HasExternallyProvidedTypes"))
                                                         }))
                                             })))),
 
@@ -3397,7 +3418,8 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                                             SyntaxFactory.TupleElement(
                                                                     SyntaxFactory.IdentifierName("bool"))
                                                                 .WithIdentifier(
-                                                                    SyntaxFactory.Identifier("HasExternallyProvidedTypes"))
+                                                                    SyntaxFactory.Identifier(
+                                                                        "HasExternallyProvidedTypes"))
                                                         }))
                                             })))),
                     SyntaxFactory.Parameter(SyntaxFactory.Identifier("token"))
@@ -3629,7 +3651,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
 
         var method = SyntaxFactory
             .MethodDeclaration(
-                SyntaxFactory.IdentifierName(EvaluationHelper.GetCasteableType(node.ReturnType)),
+                SyntaxFactory.IdentifierName(EvaluationHelper.GetCastableType(node.ReturnType)),
                 SyntaxFactory.Identifier(methodName))
             .WithModifiers(
                 SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword)))
@@ -3908,9 +3930,10 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
                                                                     SyntaxFactory.Identifier("WhereNode")),
                                                             SyntaxFactory.Token(SyntaxKind.CommaToken),
                                                             SyntaxFactory.TupleElement(
-                                                                SyntaxFactory.IdentifierName("bool"))
+                                                                    SyntaxFactory.IdentifierName("bool"))
                                                                 .WithIdentifier(
-                                                                    SyntaxFactory.Identifier("HasExternallyProvidedTypes"))
+                                                                    SyntaxFactory.Identifier(
+                                                                        "HasExternallyProvidedTypes"))
                                                         }))
                                             })))),
 
@@ -3938,7 +3961,7 @@ public class ToCSharpRewriteTreeVisitor : IToCSharpTranslationExpressionVisitor
         }
 
         var typeIdentifier = SyntaxFactory.IdentifierName(
-            EvaluationHelper.GetCasteableType(nodeReturnType));
+            EvaluationHelper.GetCastableType(nodeReturnType));
 
         return Generator.CastExpression(Generator.NullableTypeExpression(typeIdentifier),
             SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));

--- a/Musoq.Parser.Tests/ParserTests.cs
+++ b/Musoq.Parser.Tests/ParserTests.cs
@@ -151,4 +151,16 @@ public class ParserTests
 
         Assert.ThrowsException<SyntaxException>(() => parser.ComposeAll());
     }
+
+    [TestMethod]
+    [DataRow("select 1 from #some.thing() r cross apply r.Prop.Nested c")]
+    [DataRow("select 1 from #some.thing() r cross apply r.Prop.Nested c cross apply c.Prop.Nested2 d")]
+    [DataRow("select 1 from #some.thing() r cross apply r.Prop.Nested.Deeply c")]
+    public void WhenNestedPropertyUsedWithCrossApply_ShouldPass(string query)
+    {
+        var lexer = new Lexer(query, true);
+        var parser = new Parser(lexer);
+        
+        Assert.IsNotNull(parser.ComposeAll());
+    }
 }

--- a/Musoq.Parser/Musoq.Parser.csproj
+++ b/Musoq.Parser/Musoq.Parser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.2</Version>
+    <Version>4.1.0</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>

--- a/Musoq.Parser/Nodes/AccessColumnNode.cs
+++ b/Musoq.Parser/Nodes/AccessColumnNode.cs
@@ -5,19 +5,21 @@ namespace Musoq.Parser.Nodes;
 public class AccessColumnNode(string column, string alias, Type type, TextSpan span)
     : IdentifierNode(column)
 {
+    private Type _type = type;
+    private readonly string _column = column;
+
     public AccessColumnNode(string column, string alias, TextSpan span)
         : this(column, alias, typeof(void), span)
     {
-        Id = $"{nameof(AccessColumnNode)}{column}";
     }
 
     public string Alias { get; } = alias;
 
     public TextSpan Span { get; } = span;
 
-    public override Type ReturnType => type;
+    public override Type ReturnType => _type;
 
-    public override string Id { get; } = $"{nameof(AccessColumnNode)}{column}{type.Name}";
+    public override string Id => $"{nameof(AccessColumnNode)}{_column}{_type?.Name ?? string.Empty}";
 
     public override void Accept(IExpressionVisitor visitor)
     {
@@ -26,13 +28,11 @@ public class AccessColumnNode(string column, string alias, Type type, TextSpan s
 
     public override string ToString()
     {
-        if (string.IsNullOrEmpty(Alias))
-            return Name;
-        return $"{Alias}.{Name}";
+        return string.IsNullOrEmpty(Alias) ? Name : $"{Alias}.{Name}";
     }
 
     public void ChangeReturnType(Type returnType)
     {
-        type = returnType;
+        _type = returnType;
     }
 }

--- a/Musoq.Parser/Nodes/AccessMethodNode.cs
+++ b/Musoq.Parser/Nodes/AccessMethodNode.cs
@@ -7,19 +7,19 @@ namespace Musoq.Parser.Nodes;
 
 public class AccessMethodNode : Node
 {
-    public readonly FunctionToken FToken;
-
-    public AccessMethodNode(FunctionToken fToken, ArgsListNode args, ArgsListNode extraAggregateArguments, bool canSkipInjectSource,
+    public AccessMethodNode(FunctionToken functionToken, ArgsListNode args, ArgsListNode extraAggregateArguments, bool canSkipInjectSource,
         MethodInfo method = null, string alias = "")
     {
-        FToken = fToken;
+        FunctionToken = functionToken;
         Arguments = args;
         ExtraAggregateArguments = extraAggregateArguments;
         CanSkipInjectSource = canSkipInjectSource;
         Method = method;
         Alias = alias;
-        Id = $"{nameof(AccessMethodNode)}{alias}{fToken.Value}{args.Id}";
+        Id = $"{nameof(AccessMethodNode)}{alias}{functionToken.Value}{args.Id}";
     }
+    
+    public FunctionToken FunctionToken { get; }
 
     public bool CanSkipInjectSource { get; }
 
@@ -27,7 +27,7 @@ public class AccessMethodNode : Node
 
     public ArgsListNode Arguments { get; }
 
-    public string Name => FToken.Value;
+    public string Name => FunctionToken.Value;
 
     public string Alias { get; }
 

--- a/Musoq.Parser/Parser.cs
+++ b/Musoq.Parser/Parser.cs
@@ -747,20 +747,36 @@ public class Parser(Lexer lexer)
         {
             Consume(Current.TokenType);
 
-            if (Current.TokenType == TokenType.Property)
+            var properties = new List<string>();
+            var anyParsed = false;
+            
+            while (Current.TokenType == TokenType.Property)
             {
+                if (!anyParsed)
+                    anyParsed = true;
+                
                 var propertyName = Current.Value;
+                properties.Add(propertyName);
                     
                 Consume(TokenType.Property);
-                    
+
+                if (Current.TokenType == TokenType.Dot)
+                {
+                    Consume(TokenType.Dot);
+                    continue;
+                }
+                
+                break;
+            }
+            
+            if (anyParsed)
+            {
                 alias = ComposeAlias();
-                    
+            
                 if (string.IsNullOrWhiteSpace(alias))
                     throw new NotSupportedException("Alias cannot be empty when parsing From clause.");
-                    
-                var fromNode = new PropertyFromNode(alias, column.Name, propertyName);
-
-                return fromNode;
+                
+                return new PropertyFromNode(alias, column.Name, properties.ToArray());
             }
                 
             throw new NotSupportedException($"Unrecognized token {Current.TokenType} when parsing From clause.");

--- a/Musoq.Plugins.Tests/DateTimeOffsetTests.cs
+++ b/Musoq.Plugins.Tests/DateTimeOffsetTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Musoq.Plugins.Tests;
+
+[TestClass]
+public class DateTimeOffsetTests : LibraryBaseBaseTests
+{
+    [TestMethod]
+    public void WhenSingleValueAdded_ShouldPass()
+    {
+        Library.SetMinDateTimeOffset(Group, "min", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMaxDateTimeOffset(Group, "max", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        
+        var min = Library.MinDateTimeOffset(Group, "min", 0);
+        var max = Library.MaxDateTimeOffset(Group, "max", 0);
+        
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), min);
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), max);
+    }
+    
+    [TestMethod]
+    public void WhenNullValueAdded_ShouldReturnDefaultMinMax()
+    {
+        Library.SetMinDateTimeOffset(Group, "min", null);
+        Library.SetMaxDateTimeOffset(Group, "max", null);
+
+        var min = Library.MinDateTimeOffset(Group, "min", 0);
+        var max = Library.MaxDateTimeOffset(Group, "max", 0);
+
+        Assert.AreEqual(default, min);
+        Assert.AreEqual(default, max);
+    }
+
+    [TestMethod]
+    public void WhenMultipleValuesAdded_ShouldReturnCorrectMinMax()
+    {
+        Library.SetMinDateTimeOffset(Group, "min", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMinDateTimeOffset(Group, "min", new DateTimeOffset(2019, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMaxDateTimeOffset(Group, "max", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMaxDateTimeOffset(Group, "max", new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var min = Library.MinDateTimeOffset(Group, "min", 0);
+        var max = Library.MaxDateTimeOffset(Group, "max", 0);
+
+        Assert.AreEqual(new DateTimeOffset(2019, 1, 1, 0, 0, 0, TimeSpan.Zero), min);
+        Assert.AreEqual(new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero), max);
+    }
+
+    [TestMethod]
+    public void WhenInvalidDateString_ShouldReturnNull()
+    {
+        var result = Library.ToDateTimeOffset("invalid date");
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void WhenValidDateString_ShouldReturnDateTimeOffset()
+    {
+        var result = Library.ToDateTimeOffset("2020-01-01T00:00:00+00:00");
+
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), result);
+    }
+
+    [TestMethod]
+    public void WhenValidDateStringWithCulture_ShouldReturnDateTimeOffset()
+    {
+        var result = Library.ToDateTimeOffset("01/01/2020 00:00:00", "en-US");
+
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.FromHours(1)), result);
+    }
+    
+    [TestMethod]
+    public void WhenFirstAddedNullThenValue_ShouldReturnCorrectMinMax()
+    {
+        Library.SetMinDateTimeOffset(Group, "min", null);
+        Library.SetMinDateTimeOffset(Group, "min", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMaxDateTimeOffset(Group, "max", null);
+        Library.SetMaxDateTimeOffset(Group, "max", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var min = Library.MinDateTimeOffset(Group, "min", 0);
+        var max = Library.MaxDateTimeOffset(Group, "max", 0);
+
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), min);
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), max);
+    }
+
+    [TestMethod]
+    public void WhenFirstAddedValueThenNull_ShouldReturnCorrectMinMax()
+    {
+        Library.SetMinDateTimeOffset(Group, "min", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMinDateTimeOffset(Group, "min", null);
+        Library.SetMaxDateTimeOffset(Group, "max", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        Library.SetMaxDateTimeOffset(Group, "max", null);
+
+        var min = Library.MinDateTimeOffset(Group, "min", 0);
+        var max = Library.MaxDateTimeOffset(Group, "max", 0);
+
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), min);
+        Assert.AreEqual(new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), max);
+    }
+}

--- a/Musoq.Plugins/Lib/LibraryBaseDateTimeOffset.cs
+++ b/Musoq.Plugins/Lib/LibraryBaseDateTimeOffset.cs
@@ -5,21 +5,21 @@ using Musoq.Plugins.Attributes;
 namespace Musoq.Plugins;
 
 public partial class LibraryBase
-{    
+{
     /// <summary>
-    /// Converts given value to DateTimeOffset
+    /// Converts the given value to DateTimeOffset using the current culture.
     /// </summary>
-    /// <param name="value">The value</param>
-    /// <returns>Converted to DateTimeOffset value</returns>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>The converted DateTimeOffset value, or null if the conversion fails.</returns>
     [BindableMethod]
-    public DateTime? ToDateTimeOffset(string value) => ToDateTime(value, CultureInfo.CurrentCulture.Name);
+    public DateTimeOffset? ToDateTimeOffset(string value) => ToDateTimeOffset(value, CultureInfo.CurrentCulture.Name);
 
     /// <summary>
-    /// Converts given value to DateTimeOffset
+    /// Converts the given value to DateTimeOffset using the specified culture.
     /// </summary>
-    /// <param name="value">The value</param>
-    /// <param name="culture">The culture</param>
-    /// <returns>Converted to DateTimeOffset value</returns>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="culture">The culture to use for conversion.</param>
+    /// <returns>The converted DateTimeOffset value, or null if the conversion fails.</returns>
     [BindableMethod]
     public DateTimeOffset? ToDateTimeOffset(string value, string culture)
     {
@@ -30,5 +30,113 @@ public partial class LibraryBase
             return null;
 
         return result;
+    }
+
+    /// <summary>
+    /// Retrieves the maximum DateTimeOffset value from the specified group.
+    /// </summary>
+    /// <param name="group">The group to retrieve the value from.</param>
+    /// <param name="name">The name of the value to retrieve.</param>
+    /// <param name="parent">The parent group index.</param>
+    /// <returns>The maximum DateTimeOffset value.</returns>
+    [AggregationGetMethod]
+    public DateTimeOffset? MaxDateTimeOffset([InjectGroup] Group group, string name, int parent)
+    {
+        var parentGroup = GetParentGroup(group, parent);
+        return parentGroup.GetValue<DateTimeOffset?>(name);
+    }
+
+    /// <summary>
+    /// Retrieves the maximum DateTimeOffset value from the specified group.
+    /// </summary>
+    /// <param name="group">The group to retrieve the value from.</param>
+    /// <param name="name">The name of the value to retrieve.</param>
+    /// <returns>The maximum DateTimeOffset value.</returns>
+    [AggregationGetMethod]
+    public DateTimeOffset? MaxDateTimeOffset([InjectGroup] Group group, string name)
+    {
+        var parentGroup = GetParentGroup(group, 0);
+        return parentGroup.GetValue<DateTimeOffset?>(name);
+    }
+
+    /// <summary>
+    /// Sets the maximum DateTimeOffset value in the specified group.
+    /// </summary>
+    /// <param name="group">The group to set the value in.</param>
+    /// <param name="name">The name of the value to set.</param>
+    /// <param name="value">The value to set.</param>
+    /// <param name="parent">The parent group index.</param>
+    [AggregationSetMethod]
+    public void SetMaxDateTimeOffset([InjectGroup] Group group, string name, DateTimeOffset? value, int parent = 0)
+    {
+        var parentGroup = GetParentGroup(group, parent);
+
+        if (value == null)
+        {
+            parentGroup.GetOrCreateValue<DateTimeOffset?>(name, () => null);
+            return;
+        }
+
+        var maxDateTimeOffset = parentGroup.GetOrCreateValue<DateTimeOffset?>(name, DateTimeOffset.MinValue);
+        
+        if (maxDateTimeOffset is null)
+            parentGroup.SetValue(name, value.Value);
+
+        if (maxDateTimeOffset < value)
+            parentGroup.SetValue(name, value.Value);
+    }
+
+    /// <summary>
+    /// Retrieves the minimum DateTimeOffset value from the specified group.
+    /// </summary>
+    /// <param name="group">The group to retrieve the value from.</param>
+    /// <param name="name">The name of the value to retrieve.</param>
+    /// <param name="parent">The parent group index.</param>
+    /// <returns>The minimum DateTimeOffset value.</returns>
+    [AggregationGetMethod]
+    public DateTimeOffset? MinDateTimeOffset([InjectGroup] Group group, string name, int parent)
+    {
+        var parentGroup = GetParentGroup(group, parent);
+        return parentGroup.GetValue<DateTimeOffset?>(name);
+    }
+
+    /// <summary>
+    /// Retrieves the minimum DateTimeOffset value from the specified group.
+    /// </summary>
+    /// <param name="group">The group to retrieve the value from.</param>
+    /// <param name="name">The name of the value to retrieve.</param>
+    /// <returns>The minimum DateTimeOffset value.</returns>
+    [AggregationGetMethod]
+    public DateTimeOffset? MinDateTimeOffset([InjectGroup] Group group, string name)
+    {
+        var parentGroup = GetParentGroup(group, 0);
+        return parentGroup.GetValue<DateTimeOffset?>(name);
+    }
+
+    /// <summary>
+    /// Sets the minimum DateTimeOffset value in the specified group.
+    /// </summary>
+    /// <param name="group">The group to set the value in.</param>
+    /// <param name="name">The name of the value to set.</param>
+    /// <param name="value">The value to set.</param>
+    /// <param name="parent">The parent group index.</param>
+    [AggregationSetMethod]
+    public void SetMinDateTimeOffset([InjectGroup] Group group, string name, DateTimeOffset? value, int parent = 0)
+    {
+        var parentGroup = GetParentGroup(group, parent);
+
+        if (value == null)
+        {
+            parentGroup.GetOrCreateValue<DateTimeOffset?>(name, () => null);
+            return;
+        }
+
+        var minDateTimeOffset = parentGroup.GetOrCreateValue<DateTimeOffset?>(name, DateTimeOffset.MaxValue);
+        
+        if (minDateTimeOffset is null)
+            parentGroup.SetValue(name, value.Value);
+
+        if (minDateTimeOffset > value)
+            parentGroup.SetValue(name, value.Value);
     }
 }

--- a/Musoq.Plugins/Lib/LibraryBaseTimeSpan.cs
+++ b/Musoq.Plugins/Lib/LibraryBaseTimeSpan.cs
@@ -107,12 +107,12 @@ public partial class LibraryBase
         => MinTimeSpan(group, name, 0);
     
     /// <summary>
-    /// Gets the min value of a given group.
+    /// Gets the max value of a given group.
     /// </summary>
     /// <param name="group">The group object</param>
     /// <param name="name">The name</param>
     /// <param name="parent">The parent</param>
-    /// <returns>Min of group</returns>
+    /// <returns>Max of group</returns>
     [AggregationGetMethod]
     public TimeSpan? MaxTimeSpan([InjectGroup] Group group, string name, int parent)
     {

--- a/Musoq.Plugins/Musoq.Plugins.csproj
+++ b/Musoq.Plugins/Musoq.Plugins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.4.0</Version>
+    <Version>6.5.0</Version>
     <Authors>Jakub Puchała</Authors>
     <Product>Musoq</Product>
     <PackageProjectUrl>https://github.com/Puchaczov/Musoq</PackageProjectUrl>


### PR DESCRIPTION
1. Allowed properties chaining for CROSS / OUTER APPLY operators
2. Added DateTimeOffset aggregation methods
3. Fixed issue where "order by" with method invocation as part of ordering, when used with group by in conjunction with join or apply operators made crashes.